### PR TITLE
Disable Playwright artifact uploading

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,10 +92,3 @@ jobs:
 
       - name: Run Playwright tests
         run: yarn playwright test
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30


### PR DESCRIPTION
The Artifact storage quota is maxed out on the NHSUK org, which means we can't successfully run this step.