### PR TITLE
Add and use /record-async route

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -1,8 +1,8 @@
 class VaccinationsController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:record]
+  skip_before_action :verify_authenticity_token, only: [:record_async]
 
   before_action :set_campaign
-  before_action :set_child, only: %i[show record history]
+  before_action :set_child, only: %i[show record record_async history]
   before_action :set_children, only: %i[index record_template]
 
   def index
@@ -25,6 +25,13 @@ class VaccinationsController < ApplicationController
 
     flash[:success] = { title: "Record saved" }
     redirect_to campaign_vaccinations_path(@campaign)
+  end
+
+  def record_async
+    @child.update!(seen: "Vaccinated")
+    create_immunization
+
+    render json: { success: true }
   end
 
   def history

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -21,14 +21,8 @@ class VaccinationsController < ApplicationController
 
   def record
     @child.update!(seen: "Vaccinated")
-    if Settings.features.fhir_server_integration
-      imm =
-        ImmunizationFHIRBuilder.new(
-          patient_identifier: @child.nhs_number,
-          occurrence_date_time: Time.zone.now
-        )
-      imm.immunization.create # rubocop:disable Rails/SaveBang
-    end
+    create_immunization
+
     flash[:success] = { title: "Record saved" }
     redirect_to campaign_vaccinations_path(@campaign)
   end
@@ -75,5 +69,16 @@ class VaccinationsController < ApplicationController
 
   def set_children
     @children = @campaign.children.order(:first_name, :last_name)
+  end
+
+  def create_immunization
+    if Settings.features.fhir_server_integration
+      imm =
+        ImmunizationFHIRBuilder.new(
+          patient_identifier: @child.nhs_number,
+          occurrence_date_time: Time.zone.now
+        )
+      imm.immunization.create # rubocop:disable Rails/SaveBang
+    end
   end
 end

--- a/app/javascript/serviceworker/main.js
+++ b/app/javascript/serviceworker/main.js
@@ -28,13 +28,9 @@ const flushRequest = async (request) => {
     const response = await fetch(request.url, {
       method: "PUT",
       body: JSON.stringify(request.data),
-      redirect: "manual",
     });
 
-    // Unfollowed redirects have a status code of 0
-    const requestSuccessful = response.status === 0;
-
-    if (requestSuccessful) {
+    if (response.status === 200) {
       deleteRequest(request.id);
     } else {
       console.debug(

--- a/app/javascript/serviceworker/record-route.js
+++ b/app/javascript/serviceworker/record-route.js
@@ -22,7 +22,9 @@ export const recordRouteHandler = async ({ request }) => {
     const campaignId = getCampaignIdFromURL(request.url);
     const campaignUrl = recordTemplateURL(campaignId);
 
-    saveRequest(clonedRequest);
+    const url = clonedRequest.url + "-async";
+
+    saveRequest(url, clonedRequest);
 
     var response = await match(campaignUrl);
   }

--- a/app/javascript/serviceworker/store.spec.ts
+++ b/app/javascript/serviceworker/store.spec.ts
@@ -23,7 +23,7 @@ describe("saveRequest and getAllRequests", () => {
 
     request.formData = formDataMock;
 
-    await saveRequest(request);
+    await saveRequest(request.url, request);
 
     const requests = await getAllRequests();
 
@@ -50,7 +50,7 @@ describe("deleteRequest", () => {
 
     request.formData = formDataMock;
 
-    await saveRequest(request);
+    await saveRequest(request.url, request);
 
     await deleteRequest(1);
 

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -36,12 +36,12 @@ const openTx = async (mode: "readwrite" | "readonly") => {
   return db.transaction("requests", mode);
 };
 
-export const saveRequest = async (request: Request) => {
+export const saveRequest = async (url: string, request: Request) => {
   const requestData = await request.formData();
   const data = Object.fromEntries(requestData);
 
   const tx = await openTx("readwrite");
-  await tx.store.add({ url: request.url, data });
+  await tx.store.add({ url, data });
   await tx.done;
 };
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
               as: :vaccinations,
               controller: :vaccinations do
       put "record", on: :member
+      put "record-async", on: :member
       get "history", on: :member
       get "show-template", on: :collection
       get "record-template", on: :collection

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@playwright/test": "^1.31.1",
     "@prettier/plugin-ruby": "^3.2.2",
+    "@types/jest": "^29.4.0",
     "esbuild-jest": "^0.5.0",
     "fake-indexeddb": "^4.0.1",
     "jest": "^29.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,6 +1544,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^29.4.0":
+  version "29.4.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.4.0.tgz#a8444ad1704493e84dbf07bb05990b275b3b9206"
+  integrity sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
@@ -2562,7 +2570,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expect@^29.4.3:
+expect@^29.0.0, expect@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.4.3.tgz#5e47757316df744fe3b8926c3ae8a3ebdafff7fe"
   integrity sha512-uC05+Q7eXECFpgDrHdXA4k2rpMyStAYPItEDLyQDo5Ta7fVkJnNA/4zh/OIVkVVNZ1oOK1PipQoyNjuZ6sz6Dg==
@@ -4338,7 +4346,7 @@ pretty-bytes@^5.3.0:
   resolved "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
-pretty-format@^29.4.3:
+pretty-format@^29.0.0, pretty-format@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.4.3.tgz#25500ada21a53c9e8423205cf0337056b201244c"
   integrity sha512-cvpcHTc42lcsvOOAzd3XuNWTcvk1Jmnzqeu+WsOuiPmxUJTnkbAcFNsRKvEpBEUFVUgy/GTZLulZDcDEi+CIlA==


### PR DESCRIPTION
This adds the CSRF protection back to the `/record` route and creates a new `/record-async` route. We still have to add another layer of auth to this, which is coming in a follow-up PR.

Review commit by commit.