### PR TITLE
Implement manual NetworkFirst, CacheFirst strategies

### DIFF
--- a/app/javascript/serviceworker/cache.js
+++ b/app/javascript/serviceworker/cache.js
@@ -1,16 +1,16 @@
-import { cacheNames } from "workbox-core";
+import { cacheName } from "./network";
 
 export const addAll = async (requests) => {
-  const cache = await caches.open(cacheNames.runtime);
+  const cache = await caches.open(cacheName);
   return await cache.addAll(requests);
 };
 
 export const match = async (url) => {
-  const cache = await caches.open(cacheNames.runtime);
+  const cache = await caches.open(cacheName);
   return await cache.match(url);
 };
 
 export const put = async (request, response) => {
-  const cache = await caches.open(cacheNames.runtime);
+  const cache = await caches.open(cacheName);
   return await cache.put(request, response);
 };

--- a/app/javascript/serviceworker/network.spec.ts
+++ b/app/javascript/serviceworker/network.spec.ts
@@ -1,0 +1,49 @@
+require("jest-fetch-mock").enableMocks();
+import { cacheName, cacheOnly, networkFirst } from "./network";
+
+const mockCache = {
+  match: jest.fn(() => "test"),
+  put: jest.fn(),
+};
+
+const mockCaches = {
+  open: jest.fn().mockResolvedValue(mockCache),
+};
+
+Object.defineProperty(global, "caches", {
+  value: mockCaches,
+});
+
+describe("cacheOnly", () => {
+  test("returns cached response if available", async () => {
+    const request = new Request("https://example.com/test");
+    const response = await cacheOnly(request);
+
+    expect(mockCaches.open).toHaveBeenCalledWith(cacheName);
+    expect(mockCache.match).toHaveBeenCalledWith(request, { ignoreVary: true });
+    expect(response).toEqual("test");
+  });
+});
+
+describe("networkFirst", () => {
+  test("returns network response if available", async () => {
+    const request = new Request("https://example.com/test");
+    const response = await networkFirst(request);
+
+    expect(mockCaches.open).toHaveBeenCalledWith(cacheName);
+    expect(mockCache.put).toHaveBeenCalled();
+    expect(response).toHaveProperty("status", 200);
+  });
+
+  test("returns cached response if network request fails", async () => {
+    // @ts-ignore
+    fetch.mockRejectedValueOnce(new Error("test"));
+
+    const request = new Request("https://example.com/test");
+    const response = await networkFirst(request);
+
+    expect(mockCaches.open).toHaveBeenCalledWith(cacheName);
+    expect(mockCache.match).toHaveBeenCalledWith(request, { ignoreVary: true });
+    expect(response).toEqual("test");
+  });
+});

--- a/app/javascript/serviceworker/network.ts
+++ b/app/javascript/serviceworker/network.ts
@@ -1,0 +1,26 @@
+const defaultCacheName = "offline-v1";
+
+export const cacheName = defaultCacheName;
+
+export const cacheOnly = async (
+  request: Request,
+  cacheName: string = defaultCacheName
+): Promise<Response> => {
+  const cache = await caches.open(cacheName);
+  const cachedResponse = await cache.match(request, { ignoreVary: true });
+  return cachedResponse;
+};
+
+export const networkFirst = async (
+  request: Request,
+  cacheName: string = defaultCacheName
+): Promise<Response> => {
+  try {
+    const networkResponse = await fetch(request);
+    const cache = await caches.open(cacheName);
+    await cache.put(request, networkResponse.clone());
+    return networkResponse;
+  } catch (err) {
+    return cacheOnly(request, cacheName);
+  }
+};


### PR DESCRIPTION
These don't use Workbox and can be customised to use IndexedDB behind the scenes. This is coming in a follow-up PR.