### PR TITLE
Refactor store methods

### DIFF
--- a/app/javascript/serviceworker/main.js
+++ b/app/javascript/serviceworker/main.js
@@ -5,7 +5,7 @@ import { isOnline, refreshOnlineStatus } from "./online-status";
 import { handler as messageHandler } from "./messages";
 import { childRoute, childRouteHandler } from "./child-route";
 import { recordRoute, recordRouteHandler } from "./record-route";
-import { getAllRequests, deleteRequest } from "./store";
+import { getAll, destroy } from "./store";
 
 const setDefaultHandler = () => {
   self.addEventListener("fetch", (event) => {
@@ -25,7 +25,7 @@ const flushRequest = async (request) => {
     const { token } = await csrf.json();
     const response = await fetch(request.url, {
       method: "PUT",
-      body: JSON.stringify(request.data),
+      body: JSON.stringify(request.body),
       redirect: "manual",
       headers: {
         "X-CSRF-Token": token,
@@ -36,7 +36,7 @@ const flushRequest = async (request) => {
     const requestSuccessful = response.status === 0;
 
     if (requestSuccessful) {
-      deleteRequest(request.id);
+      destroy("delayedRequests", request.id);
     } else {
       console.debug(
         "[Service Worker refreshOnlineStatus] error sending request:",
@@ -53,7 +53,7 @@ const flushRequest = async (request) => {
 };
 
 refreshOnlineStatus(async () => {
-  const requests = await getAllRequests();
+  const requests = await getAll("delayedRequests");
 
   await Promise.all(requests.map(flushRequest));
 });

--- a/app/javascript/serviceworker/record-route.js
+++ b/app/javascript/serviceworker/record-route.js
@@ -1,6 +1,6 @@
 import { isOnline } from "./online-status";
 import { match } from "./cache";
-import { saveRequest } from "./store";
+import { add } from "./store";
 
 const getCampaignIdFromURL = (url) => url.match("/campaigns/(\\d+)/")[1];
 
@@ -12,18 +12,18 @@ export const recordRoute = new RegExp(
 );
 
 export const recordRouteHandler = async ({ request }) => {
-  const data = await request.formData();
   const clonedRequest = request.clone();
+  const data = Object.fromEntries(await request.formData());
 
   try {
     if (!isOnline()) throw new NetworkError("Offline");
 
-    var response = await fetch(request, { method: "POST" });
+    var response = await fetch(clonedRequest, { method: "POST" });
   } catch (err) {
     const campaignId = getCampaignIdFromURL(request.url);
     const campaignUrl = recordTemplateURL(campaignId);
 
-    saveRequest(clonedRequest.url, data);
+    add("delayedRequests", clonedRequest.url, data);
 
     var response = await match(campaignUrl);
   }

--- a/app/javascript/serviceworker/record-route.js
+++ b/app/javascript/serviceworker/record-route.js
@@ -12,6 +12,7 @@ export const recordRoute = new RegExp(
 );
 
 export const recordRouteHandler = async ({ request }) => {
+  const data = await request.formData();
   const clonedRequest = request.clone();
 
   try {
@@ -22,7 +23,7 @@ export const recordRouteHandler = async ({ request }) => {
     const campaignId = getCampaignIdFromURL(request.url);
     const campaignUrl = recordTemplateURL(campaignId);
 
-    saveRequest(clonedRequest);
+    saveRequest(clonedRequest.url, data);
 
     var response = await match(campaignUrl);
   }

--- a/app/javascript/serviceworker/record-route.spec.js
+++ b/app/javascript/serviceworker/record-route.spec.js
@@ -8,6 +8,7 @@ jest.mock("./store");
 
 const url = "/campaigns/1/children/2/record";
 const request = new Request(url);
+request.formData = () => Promise.resolve("foo");
 
 describe("recordRoute", () => {
   test("matches correctly", () => {

--- a/app/javascript/serviceworker/record-route.spec.js
+++ b/app/javascript/serviceworker/record-route.spec.js
@@ -8,7 +8,7 @@ jest.mock("./store");
 
 const url = "/campaigns/1/children/2/record";
 const request = new Request(url);
-request.formData = () => Promise.resolve("foo");
+request.formData = () => Promise.resolve([["foo", "bar"]]);
 
 describe("recordRoute", () => {
   test("matches correctly", () => {

--- a/app/javascript/serviceworker/store.spec.ts
+++ b/app/javascript/serviceworker/store.spec.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import FDBFactory from "fake-indexeddb/lib/FDBFactory";
-import { saveRequest, getAllRequests, deleteRequest } from "./store";
+import { add, getAll, destroy } from "./store";
 
 beforeEach(() => {
   // Reset database https://github.com/dumbmatter/fakeIndexedDB/issues/40
@@ -9,9 +9,9 @@ beforeEach(() => {
 
 describe("saveRequest and getAllRequests", () => {
   it("save and get the requests", async () => {
-    await saveRequest("/api", { name: "John" });
+    await add("delayedRequests", "/api", { name: "John" });
 
-    const requests = await getAllRequests();
+    const requests = await getAll("delayedRequests");
 
     expect(requests).toMatchInlineSnapshot(`
       [
@@ -29,11 +29,11 @@ describe("saveRequest and getAllRequests", () => {
 
 describe("deleteRequest", () => {
   it("delete a request", async () => {
-    await saveRequest("/api", { name: "John" });
+    await add("delayedRequests", "/api", { name: "John" });
 
-    await deleteRequest(1);
+    await destroy("delayedRequests", 1);
 
-    const requests = await getAllRequests();
+    const requests = await getAll("delayedRequests");
 
     expect(requests).toMatchInlineSnapshot(`[]`);
   });

--- a/app/javascript/serviceworker/store.spec.ts
+++ b/app/javascript/serviceworker/store.spec.ts
@@ -1,13 +1,6 @@
-import "jest-fetch-mock";
 import "fake-indexeddb/auto";
 import FDBFactory from "fake-indexeddb/lib/FDBFactory";
 import { saveRequest, getAllRequests, deleteRequest } from "./store";
-
-const formDataMock = jest.fn(() => {
-  const form = new FormData();
-  form.append("name", "John");
-  return Promise.resolve(form);
-});
 
 beforeEach(() => {
   // Reset database https://github.com/dumbmatter/fakeIndexedDB/issues/40
@@ -16,21 +9,14 @@ beforeEach(() => {
 
 describe("saveRequest and getAllRequests", () => {
   it("save and get the requests", async () => {
-    const request = new Request("/api", {
-      method: "POST",
-      body: JSON.stringify({ name: "John" }),
-    });
-
-    request.formData = formDataMock;
-
-    await saveRequest(request);
+    await saveRequest("/api", { name: "John" });
 
     const requests = await getAllRequests();
 
     expect(requests).toMatchInlineSnapshot(`
       [
         {
-          "data": {
+          "body": {
             "name": "John",
           },
           "id": 1,
@@ -43,14 +29,7 @@ describe("saveRequest and getAllRequests", () => {
 
 describe("deleteRequest", () => {
   it("delete a request", async () => {
-    const request = new Request("/api", {
-      method: "POST",
-      body: JSON.stringify({ name: "John" }),
-    });
-
-    request.formData = formDataMock;
-
-    await saveRequest(request);
+    await saveRequest("/api", { name: "John" });
 
     await deleteRequest(1);
 

--- a/app/javascript/serviceworker/store.spec.ts
+++ b/app/javascript/serviceworker/store.spec.ts
@@ -1,13 +1,13 @@
 import "fake-indexeddb/auto";
 import FDBFactory from "fake-indexeddb/lib/FDBFactory";
-import { add, getAll, destroy } from "./store";
+import { add, destroy, getByUrl, getAll } from "./store";
 
 beforeEach(() => {
   // Reset database https://github.com/dumbmatter/fakeIndexedDB/issues/40
   indexedDB = new FDBFactory();
 });
 
-describe("saveRequest and getAllRequests", () => {
+describe("add and getAll", () => {
   it("save and get the requests", async () => {
     await add("delayedRequests", "/api", { name: "John" });
 
@@ -27,7 +27,25 @@ describe("saveRequest and getAllRequests", () => {
   });
 });
 
-describe("deleteRequest", () => {
+describe("getByUrl", () => {
+  it("gets a request by url", async () => {
+    await add("delayedRequests", "/api", { name: "John" });
+
+    const request = await getByUrl("delayedRequests", "/api");
+
+    expect(request).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "name": "John",
+        },
+        "id": 1,
+        "url": "/api",
+      }
+    `);
+  });
+});
+
+describe("destroy", () => {
   it("delete a request", async () => {
     await add("delayedRequests", "/api", { name: "John" });
 

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -1,5 +1,7 @@
 import { openDB, DBSchema } from "idb";
 
+type StoreName = "delayedRequests";
+
 interface RequestObject {
   id?: number;
   url: string;
@@ -23,7 +25,7 @@ interface Db {
 const DB_NAME = "offline";
 const DB_VERSION = 1;
 
-const openTx = async (mode: "readwrite" | "readonly") => {
+const openTx = async (storeName: StoreName, mode: "readwrite" | "readonly") => {
   const db = await openDB<OfflineDatabase>(DB_NAME, DB_VERSION, {
     upgrade(db: Db) {
       db.createObjectStore("delayedRequests", {
@@ -33,23 +35,25 @@ const openTx = async (mode: "readwrite" | "readonly") => {
     },
   });
 
-  return db.transaction("delayedRequests", mode);
+  return db.transaction(storeName, mode);
 };
 
-export const saveRequest = async (url: string, body: any) => {
-  const tx = await openTx("readwrite");
+export const add = async (storeName: StoreName, url: string, body: any) => {
+  const tx = await openTx(storeName, "readwrite");
   await tx.store.add({ url, body });
   await tx.done;
 };
 
-export const deleteRequest = async (id: number) => {
-  const tx = await openTx("readwrite");
+export const destroy = async (storeName: StoreName, id: number) => {
+  const tx = await openTx(storeName, "readwrite");
   await tx.store.delete(id);
   await tx.done;
 };
 
-export const getAllRequests = async (): Promise<RequestObject[]> => {
-  const tx = await openTx("readonly");
+export const getAll = async (
+  storeName: StoreName
+): Promise<RequestObject[]> => {
+  const tx = await openTx(storeName, "readonly");
   const requests = await tx.store.getAll();
   await tx.done;
 

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -3,7 +3,7 @@ import { openDB, DBSchema } from "idb";
 interface RequestObject {
   id?: number;
   url: string;
-  data: any;
+  body: any;
 }
 
 interface OfflineDatabase extends DBSchema {
@@ -36,12 +36,9 @@ const openTx = async (mode: "readwrite" | "readonly") => {
   return db.transaction("requests", mode);
 };
 
-export const saveRequest = async (request: Request) => {
-  const requestData = await request.formData();
-  const data = Object.fromEntries(requestData);
-
+export const saveRequest = async (url: string, body: any) => {
   const tx = await openTx("readwrite");
-  await tx.store.add({ url: request.url, data });
+  await tx.store.add({ url, body });
   await tx.done;
 };
 

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -58,6 +58,17 @@ export const destroy = async (storeName: StoreName, id: number) => {
   await tx.done;
 };
 
+export const getByUrl = async (
+  storeName: StoreName,
+  url: string
+): Promise<RequestObject | undefined> => {
+  const tx = await openTx(storeName, "readonly");
+  const request = await tx.store.index("url").get(url);
+  await tx.done;
+
+  return request;
+};
+
 export const getAll = async (
   storeName: StoreName
 ): Promise<RequestObject[]> => {

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -12,26 +12,34 @@ interface OfflineDatabase extends DBSchema {
   delayedRequests: {
     key: number;
     value: RequestObject;
+    indexes: { url: string };
+  };
+  cachedResponses: {
+    key: number;
+    value: RequestObject;
+    indexes: { url: string };
   };
 }
 
-interface Db {
-  createObjectStore: (
-    arg0: string,
-    arg1: { keyPath: string; autoIncrement: boolean }
-  ) => void;
-}
-
 const DB_NAME = "offline";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 const openTx = async (storeName: StoreName, mode: "readwrite" | "readonly") => {
   const db = await openDB<OfflineDatabase>(DB_NAME, DB_VERSION, {
-    upgrade(db: Db) {
-      db.createObjectStore("delayedRequests", {
+    upgrade(db) {
+      const delayedStore = db.createObjectStore("delayedRequests", {
         keyPath: "id",
         autoIncrement: true,
       });
+
+      delayedStore.createIndex("url", "url", { unique: false });
+
+      const cachedStore = db.createObjectStore("cachedResponses", {
+        keyPath: "id",
+        autoIncrement: true,
+      });
+
+      cachedStore.createIndex("url", "url", { unique: true });
     },
   });
 

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -7,7 +7,7 @@ interface RequestObject {
 }
 
 interface OfflineDatabase extends DBSchema {
-  requests: {
+  delayedRequests: {
     key: number;
     value: RequestObject;
   };
@@ -26,14 +26,14 @@ const DB_VERSION = 1;
 const openTx = async (mode: "readwrite" | "readonly") => {
   const db = await openDB<OfflineDatabase>(DB_NAME, DB_VERSION, {
     upgrade(db: Db) {
-      db.createObjectStore("requests", {
+      db.createObjectStore("delayedRequests", {
         keyPath: "id",
         autoIncrement: true,
       });
     },
   });
 
-  return db.transaction("requests", mode);
+  return db.transaction("delayedRequests", mode);
 };
 
 export const saveRequest = async (url: string, body: any) => {


### PR DESCRIPTION
Rename them and implement a new `getByUrl` method.

Also rename the POST requests table to `delayedRequests`, and add a table that will be used for `cachedResponses`. The schema can currently be shared between the two.

This is more prep-work beore we can use IndexedDB instead of the cache API in the `NetworkFirst` strategy, followed by encrypting content as it goes in/out of the cache.

Review commit by commit.