### PR TITLE
Use cache match and put in network strategies

### DIFF
--- a/app/javascript/serviceworker/cache.spec.ts
+++ b/app/javascript/serviceworker/cache.spec.ts
@@ -1,3 +1,4 @@
+require("jest-fetch-mock").enableMocks();
 import { addAll, match, put } from "./cache";
 
 const addAllMock = jest.fn();
@@ -9,7 +10,7 @@ global.caches = {
     match: matchMock,
     put: putMock,
   })),
-};
+} as any;
 
 describe("addAll", () => {
   test("works", async () => {
@@ -27,7 +28,8 @@ describe("match", () => {
 
 describe("put", () => {
   test("works", async () => {
-    await put("foo", "bar");
-    expect(putMock).toHaveBeenCalledWith("foo", "bar");
+    const response = new Response();
+    await put("foo", response);
+    expect(putMock).toHaveBeenCalledWith("foo", response);
   });
 });

--- a/app/javascript/serviceworker/cache.spec.ts
+++ b/app/javascript/serviceworker/cache.spec.ts
@@ -22,7 +22,7 @@ describe("addAll", () => {
 describe("match", () => {
   test("works", async () => {
     await match("foo");
-    expect(matchMock).toHaveBeenCalledWith("foo");
+    expect(matchMock).toHaveBeenCalledWith("foo", {});
   });
 });
 

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,16 +1,21 @@
 import { cacheName } from "./network";
 
-export const addAll = async (requests) => {
+export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   const cache = await caches.open(cacheName);
   return await cache.addAll(requests);
 };
 
-export const match = async (url) => {
+export const match = async (
+  url: RequestInfo
+): Promise<Response | undefined> => {
   const cache = await caches.open(cacheName);
   return await cache.match(url);
 };
 
-export const put = async (request, response) => {
+export const put = async (
+  request: RequestInfo,
+  response: Response
+): Promise<void> => {
   const cache = await caches.open(cacheName);
   return await cache.put(request, response);
 };

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,4 +1,6 @@
-import { cacheName } from "./network";
+const defaultCacheName = "offline-v1";
+
+export const cacheName = defaultCacheName;
 
 export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   const cache = await caches.open(cacheName);

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -6,10 +6,11 @@ export const addAll = async (requests: RequestInfo[]): Promise<void> => {
 };
 
 export const match = async (
-  url: RequestInfo
+  url: RequestInfo,
+  options: CacheQueryOptions = {}
 ): Promise<Response | undefined> => {
   const cache = await caches.open(cacheName);
-  return await cache.match(url);
+  return await cache.match(url, options);
 };
 
 export const put = async (

--- a/app/javascript/serviceworker/network.spec.ts
+++ b/app/javascript/serviceworker/network.spec.ts
@@ -1,5 +1,5 @@
 require("jest-fetch-mock").enableMocks();
-import { cacheName, cacheOnly, networkFirst } from "./network";
+import { cacheOnly, networkFirst } from "./network";
 
 const mockCache = {
   match: jest.fn(() => "test"),
@@ -10,16 +10,14 @@ const mockCaches = {
   open: jest.fn().mockResolvedValue(mockCache),
 };
 
-Object.defineProperty(global, "caches", {
-  value: mockCaches,
-});
+global.caches = mockCaches as any;
 
 describe("cacheOnly", () => {
   test("returns cached response if available", async () => {
     const request = new Request("https://example.com/test");
     const response = await cacheOnly(request);
 
-    expect(mockCaches.open).toHaveBeenCalledWith(cacheName);
+    expect(mockCaches.open).toHaveBeenCalled();
     expect(mockCache.match).toHaveBeenCalledWith(request, { ignoreVary: true });
     expect(response).toEqual("test");
   });
@@ -30,7 +28,7 @@ describe("networkFirst", () => {
     const request = new Request("https://example.com/test");
     const response = await networkFirst(request);
 
-    expect(mockCaches.open).toHaveBeenCalledWith(cacheName);
+    expect(mockCaches.open).toHaveBeenCalled();
     expect(mockCache.put).toHaveBeenCalled();
     expect(response).toHaveProperty("status", 200);
   });
@@ -42,7 +40,7 @@ describe("networkFirst", () => {
     const request = new Request("https://example.com/test");
     const response = await networkFirst(request);
 
-    expect(mockCaches.open).toHaveBeenCalledWith(cacheName);
+    expect(mockCaches.open).toHaveBeenCalled();
     expect(mockCache.match).toHaveBeenCalledWith(request, { ignoreVary: true });
     expect(response).toEqual("test");
   });

--- a/app/javascript/serviceworker/network.ts
+++ b/app/javascript/serviceworker/network.ts
@@ -1,26 +1,16 @@
-const defaultCacheName = "offline-v1";
+import { match, put } from "./cache";
 
-export const cacheName = defaultCacheName;
-
-export const cacheOnly = async (
-  request: Request,
-  cacheName: string = defaultCacheName
-): Promise<Response> => {
-  const cache = await caches.open(cacheName);
-  const cachedResponse = await cache.match(request, { ignoreVary: true });
+export const cacheOnly = async (request: Request): Promise<Response> => {
+  const cachedResponse = await match(request, { ignoreVary: true });
   return cachedResponse;
 };
 
-export const networkFirst = async (
-  request: Request,
-  cacheName: string = defaultCacheName
-): Promise<Response> => {
+export const networkFirst = async (request: Request): Promise<Response> => {
   try {
     const networkResponse = await fetch(request);
-    const cache = await caches.open(cacheName);
-    await cache.put(request, networkResponse.clone());
+    await put(request, networkResponse.clone());
     return networkResponse;
   } catch (err) {
-    return cacheOnly(request, cacheName);
+    return cacheOnly(request);
   }
 };


### PR DESCRIPTION
Defer to our module instead of calling `caches.open` directly. This will allow us to change the caching mechanism behind the scenes while not having to update all the call sites.

Refactor some other things on the way there, see commits.

This is part of shifting from using the Cache API to IDB as the backing store, and will be done in roughly 3 parts:

0: This PR, prepwork
1: Adding `store` calls to the `put` and `addAll` methods in the cache module, to start storing things in `idb` but not yet reading them
2: Adding `store` calls to the `match` function, completely shifting the implementation from using the Cache API to IDB
3: Removing Cache API related code

Following this, we can move on to actually encrypting/decrypting requests.