### PR TITLE
Add requests to idb through NetworkFirst strategy

### DIFF
--- a/app/javascript/serviceworker/cache.spec.ts
+++ b/app/javascript/serviceworker/cache.spec.ts
@@ -1,5 +1,8 @@
 require("jest-fetch-mock").enableMocks();
 import { addAll, match, put } from "./cache";
+import { add } from "./store";
+
+jest.mock("./store");
 
 const addAllMock = jest.fn();
 const matchMock = jest.fn();
@@ -11,6 +14,8 @@ global.caches = {
     put: putMock,
   })),
 } as any;
+
+jest.mock("./store");
 
 describe("addAll", () => {
   test("works", async () => {
@@ -27,9 +32,18 @@ describe("match", () => {
 });
 
 describe("put", () => {
-  test("works", async () => {
+  test("caches to the Cache API", async () => {
     const response = new Response();
     await put("foo", response);
     expect(putMock).toHaveBeenCalledWith("foo", response);
+  });
+
+  test("caches to the store", async () => {
+    const request = new Request("https://example.com/test");
+    const response = new Response();
+    await put(request, response);
+
+    const body = await response.clone().blob();
+    expect(add).toHaveBeenCalledWith("cachedResponses", request.url, body);
   });
 });

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,3 +1,5 @@
+import { add } from "./store";
+
 const cacheName = "offline-v1";
 
 export const addAll = async (requests: RequestInfo[]): Promise<void> => {
@@ -17,6 +19,10 @@ export const put = async (
   request: RequestInfo,
   response: Response
 ): Promise<void> => {
+  const url = typeof request === "string" ? request : request.url;
+  const body = await response.clone().blob();
+  await add("cachedResponses", url, body);
+
   const cache = await caches.open(cacheName);
   return await cache.put(request, response);
 };

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,6 +1,4 @@
-const defaultCacheName = "offline-v1";
-
-export const cacheName = defaultCacheName;
+const cacheName = "offline-v1";
 
 export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   const cache = await caches.open(cacheName);

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -8,11 +8,11 @@ export const addAll = async (requests: RequestInfo[]): Promise<void> => {
 };
 
 export const match = async (
-  url: RequestInfo,
+  request: RequestInfo,
   options: CacheQueryOptions = {}
 ): Promise<Response | undefined> => {
   const cache = await caches.open(cacheName);
-  return await cache.match(url, options);
+  return await cache.match(request, options);
 };
 
 export const put = async (

--- a/app/javascript/serviceworker/network.ts
+++ b/app/javascript/serviceworker/network.ts
@@ -1,8 +1,7 @@
 import { match, put } from "./cache";
 
 export const cacheOnly = async (request: Request): Promise<Response> => {
-  const cachedResponse = await match(request, { ignoreVary: true });
-  return cachedResponse;
+  return await match(request, { ignoreVary: true });
 };
 
 export const networkFirst = async (request: Request): Promise<Response> => {

--- a/app/javascript/serviceworker/store.spec.ts
+++ b/app/javascript/serviceworker/store.spec.ts
@@ -7,11 +7,54 @@ beforeEach(() => {
   indexedDB = new FDBFactory();
 });
 
-describe("add and getAll", () => {
-  it("save and get the requests", async () => {
+describe("add", () => {
+  it("saves the request", async () => {
     await add("delayedRequests", "/api", { name: "John" });
 
     const requests = await getAll("delayedRequests");
+
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "body": {
+            "name": "John",
+          },
+          "id": 1,
+          "url": "/api",
+        },
+      ]
+    `);
+  });
+
+  it("dedupes requests by url", async () => {
+    await add("cachedResponses", "/api", { name: "John" });
+    await add("cachedResponses", "/api", { name: "John" });
+
+    const requests = await getAll("cachedResponses");
+
+    expect(requests).toMatchInlineSnapshot(`
+      [
+        {
+          "body": {
+            "name": "John",
+          },
+          "id": 1,
+          "url": "/api",
+        },
+      ]
+    `);
+  });
+});
+
+describe("getAll", () => {
+  it("returns all requests", async () => {
+    let requests = await getAll("delayedRequests");
+
+    expect(requests).toMatchInlineSnapshot(`[]`);
+
+    await add("delayedRequests", "/api", { name: "John" });
+
+    requests = await getAll("delayedRequests");
 
     expect(requests).toMatchInlineSnapshot(`
       [
@@ -46,7 +89,7 @@ describe("getByUrl", () => {
 });
 
 describe("destroy", () => {
-  it("delete a request", async () => {
+  it("deletes a request", async () => {
     await add("delayedRequests", "/api", { name: "John" });
 
     await destroy("delayedRequests", 1);

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -48,7 +48,14 @@ const openTx = async (storeName: StoreName, mode: "readwrite" | "readonly") => {
 
 export const add = async (storeName: StoreName, url: string, body: any) => {
   const tx = await openTx(storeName, "readwrite");
-  await tx.store.add({ url, body });
+  const request = await tx.store.index("url").get(url);
+
+  if (storeName === "cachedResponses" && request) {
+    await tx.store.put({ ...request, body });
+  } else {
+    await tx.store.add({ url, body });
+  }
+
   await tx.done;
 };
 

--- a/app/javascript/serviceworker/store.ts
+++ b/app/javascript/serviceworker/store.ts
@@ -1,6 +1,6 @@
 import { openDB, DBSchema } from "idb";
 
-type StoreName = "delayedRequests";
+type StoreName = "cachedResponses" | "delayedRequests";
 
 interface RequestObject {
   id?: number;


### PR DESCRIPTION
The NetworkFirst strategy will continue to use the CacheAPI mainly, but this adds initial support to additionally save the requests to IDB.

Few other refactors done on the way, see commits.