### PR TITLE
Fetch cached requests from idb

### DIFF
--- a/app/javascript/serviceworker/cache.spec.ts
+++ b/app/javascript/serviceworker/cache.spec.ts
@@ -5,7 +5,7 @@ import { add, getByUrl } from "./store";
 jest.mock("./store");
 
 describe("addAll", () => {
-  test("works", async () => {
+  test("fetches and adds all the passed in requests", async () => {
     const urls = ["https://example.com/test", "https://example.com/test2"];
     const firstResponse = new Response("foo");
     const firstBlob = await firstResponse.clone().blob();
@@ -23,13 +23,11 @@ describe("addAll", () => {
 });
 
 describe("match", () => {
-  test("works", async () => {
-    const request = new Request("https://example.com/test");
-    const response = new Response("foo");
+  test("matches a request with its response", async () => {
     (getByUrl as jest.Mock).mockResolvedValueOnce({ body: "foo" });
 
-    const result = await match(request);
-    expect(result).toEqual(response);
+    const result = await match("test");
+    expect(result).toEqual(new Response("foo"));
   });
 
   test("returns undefined if no match", async () => {
@@ -42,16 +40,13 @@ describe("match", () => {
 
 describe("put", () => {
   test("caches to the store", async () => {
-    const first = "https://example.com/test";
-    const second = "https://example.com/test2";
+    const url = "https://example.com/test";
 
     const response = new Response();
     const body = await response.clone().blob();
 
-    await put(first, response);
-    await put(new Request(second), response);
+    await put(url, response);
 
-    expect(add).toHaveBeenCalledWith("cachedResponses", first, body);
-    expect(add).toHaveBeenCalledWith("cachedResponses", second, body);
+    expect(add).toHaveBeenCalledWith("cachedResponses", url, body);
   });
 });

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,6 +1,6 @@
 import { add, getByUrl } from "./store";
 
-const url = (request: RequestInfo): string => new Request(request).url;
+const urlOf = (request: RequestInfo): string => new Request(request).url;
 
 export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   const responses = await Promise.all(
@@ -8,14 +8,14 @@ export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   );
 
   await Promise.all(
-    requests.map((request, index) => put(url(request), responses[index]))
+    requests.map((request, index) => put(urlOf(request), responses[index]))
   );
 };
 
 export const match = async (
   request: RequestInfo
 ): Promise<Response | undefined> => {
-  const requestObject = await getByUrl("cachedResponses", url(request));
+  const requestObject = await getByUrl("cachedResponses", urlOf(request));
   return requestObject ? new Response(requestObject.body) : undefined;
 };
 
@@ -24,5 +24,5 @@ export const put = async (
   response: Response
 ): Promise<void> => {
   const body = await response.clone().blob();
-  return await add("cachedResponses", url(request), body);
+  return await add("cachedResponses", urlOf(request), body);
 };

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,7 +1,6 @@
 import { add, getByUrl } from "./store";
 
-const url = (request: RequestInfo): string =>
-  typeof request === "string" ? request : request.url;
+const url = (request: RequestInfo): string => new Request(request).url;
 
 export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   const responses = await Promise.all(
@@ -9,7 +8,7 @@ export const addAll = async (requests: RequestInfo[]): Promise<void> => {
   );
 
   await Promise.all(
-    requests.map((request, index) => put(request, responses[index]))
+    requests.map((request, index) => put(url(request), responses[index]))
   );
 };
 

--- a/app/javascript/serviceworker/network.spec.ts
+++ b/app/javascript/serviceworker/network.spec.ts
@@ -10,7 +10,7 @@ describe("cacheOnly", () => {
     const request = new Request("https://example.com/test");
     const response = await cacheOnly(request);
 
-    expect(match).toHaveBeenCalledWith(request, { ignoreVary: true });
+    expect(match).toHaveBeenCalledWith(request);
     expect(response).toEqual("test");
   });
 });
@@ -31,7 +31,7 @@ describe("networkFirst", () => {
     const request = new Request("https://example.com/test");
     const response = await networkFirst(request);
 
-    expect(match).toHaveBeenCalledWith(request, { ignoreVary: true });
+    expect(match).toHaveBeenCalledWith(request);
     expect(response).toEqual("test");
   });
 });

--- a/app/javascript/serviceworker/network.ts
+++ b/app/javascript/serviceworker/network.ts
@@ -1,7 +1,7 @@
 import { match, put } from "./cache";
 
 export const cacheOnly = async (request: Request): Promise<Response> => {
-  return await match(request, { ignoreVary: true });
+  return await match(request);
 };
 
 export const networkFirst = async (request: Request): Promise<Response> => {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="nhsuk-template">
   <head>
+    <meta charset="utf-8">
     <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
 
     <%= csrf_meta_tags %>


### PR DESCRIPTION
This migrates the `cache` methods to use `idb` as the backing store instead of the Cache API.

There are a few bugs left over, but functionality is good enough to the point that tests pass. We can tackle these in follow-up PRs:

- [ ] Fix redirects, save status codes
- [ ] Fix regexp matching, registerRoute calls
- [ ] Serialise/deserialise responses properly
- [ ] Make key lookup a URL and list of headers

See commits.