### PR TITLE
Disable browser caching for children.json

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -4,6 +4,7 @@ class VaccinationsController < ApplicationController
   before_action :set_children, only: %i[index record_template]
 
   def index
+    set_disable_cache_headers
     respond_to do |format|
       format.html
       format.json { render json: @children.index_by(&:id) }
@@ -73,5 +74,11 @@ class VaccinationsController < ApplicationController
 
   def set_children
     @children = @campaign.children.order(:first_name, :last_name)
+  end
+
+  def set_disable_cache_headers
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -7,4 +7,14 @@ RSpec.describe "Pages", type: :request do
       expect(response).to redirect_to("/dashboard")
     end
   end
+
+  describe "GET /campaigns/:campaign_id/children.json" do
+    it "has a no-store cache header" do
+      campaign = create(:campaign)
+      get "/campaigns/#{campaign.id}/children.json"
+      expect(response.headers["Cache-Control"]).to eq("no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"]).to eq("0")
+    end
+  end
 end


### PR DESCRIPTION
This prevents the browser from saving a request for this file to the Cache_Data folder.

This is just the bare minimum for now, but we'll probably expand this to other files or perhaps create a separate controller to inherit from for sensitive endpoints and data.

There might be downsides to setting aggressive no-cache headers; it potentially breaks the back button in situations of flaky connectivity.