### PR TITLE
Use for instead of apply when converting to base64

### DIFF
--- a/app/javascript/serviceworker/simple-crypto.test.ts
+++ b/app/javascript/serviceworker/simple-crypto.test.ts
@@ -30,4 +30,13 @@ describe("SimpleCrypto", () => {
     const decrypted = await secret.decrypt(encrypted);
     expect(decrypted).toEqual(payload);
   });
+
+  test("works with a large payload", async () => {
+    const largePayload = new Array(500000).fill("x").join("");
+    const encrypted = await secret.encrypt(largePayload);
+    expect(encrypted).not.toEqual(largePayload);
+
+    const decrypted = await secret.decrypt(encrypted);
+    expect(decrypted).toEqual(largePayload);
+  });
 });


### PR DESCRIPTION
Turns out that using apply can result in a `Maximum call stack size exceeded` error with sufficiently large inputs...