### PR TITLE
Encrypt/decrypt pages when caching

### DIFF
--- a/app/javascript/serviceworker/cache.spec.ts
+++ b/app/javascript/serviceworker/cache.spec.ts
@@ -3,37 +3,35 @@ import { addAll, match, put } from "./cache";
 import { add, getByUrl } from "./store";
 
 jest.mock("./store");
+jest.mock("./simple-crypto");
 
 describe("addAll", () => {
   test("fetches and adds all the passed in requests", async () => {
     const urls = ["https://example.com/test", "https://example.com/test2"];
-    const firstResponse = new Response("foo");
-    const firstBlob = await firstResponse.clone().blob();
-    const secondResponse = new Response("bar");
-    const secondBlob = await secondResponse.clone().blob();
 
-    (fetch as jest.Mock)
-      .mockResolvedValueOnce(firstResponse)
-      .mockResolvedValueOnce(secondResponse);
     await addAll(urls);
 
-    expect(add).toHaveBeenCalledWith("cachedResponses", urls[0], firstBlob);
-    expect(add).toHaveBeenCalledWith("cachedResponses", urls[1], secondBlob);
+    expect(add).toHaveBeenCalledWith("cachedResponses", urls[0], new Blob());
+    expect(add).toHaveBeenCalledWith("cachedResponses", urls[1], new Blob());
   });
 });
 
 describe("match", () => {
   test("matches a request with its response", async () => {
-    (getByUrl as jest.Mock).mockResolvedValueOnce({ body: "foo" });
+    (getByUrl as jest.Mock).mockResolvedValueOnce({
+      body: new Response("foo"),
+    });
 
     const result = await match("test");
-    expect(result).toEqual(new Response("foo"));
+
+    expect(result).toEqual(new Response(new Blob()));
   });
 
   test("returns undefined if no match", async () => {
     (getByUrl as jest.Mock).mockResolvedValueOnce(undefined);
 
     const result = await match("test");
+
     expect(result).toBeUndefined();
   });
 });
@@ -43,10 +41,9 @@ describe("put", () => {
     const url = "https://example.com/test";
 
     const response = new Response();
-    const body = await response.clone().blob();
 
     await put(url, response);
 
-    expect(add).toHaveBeenCalledWith("cachedResponses", url, body);
+    expect(add).toHaveBeenCalledWith("cachedResponses", url, new Blob());
   });
 });

--- a/app/javascript/serviceworker/cache.ts
+++ b/app/javascript/serviceworker/cache.ts
@@ -1,4 +1,19 @@
+import { SimpleCrypto } from "./simple-crypto";
 import { add, getByUrl } from "./store";
+
+const encryptBlob = async (blob: Blob): Promise<Blob> => {
+  const secret = new SimpleCrypto("my-passphrase", "my-salt");
+  await secret.init();
+  const encrypted = await secret.encrypt(await blob.text());
+  return new Blob([encrypted], { type: blob.type });
+};
+
+const decryptBlob = async (blob: Blob): Promise<Blob> => {
+  const secret = new SimpleCrypto("my-passphrase", "my-salt");
+  await secret.init();
+  const decrypted = await secret.decrypt(await blob.text());
+  return new Blob([decrypted], { type: blob.type });
+};
 
 const urlOf = (request: RequestInfo): string => new Request(request).url;
 
@@ -16,7 +31,10 @@ export const match = async (
   request: RequestInfo
 ): Promise<Response | undefined> => {
   const requestObject = await getByUrl("cachedResponses", urlOf(request));
-  return requestObject ? new Response(requestObject.body) : undefined;
+  if (!requestObject) return undefined;
+
+  const decryptedBlob = await decryptBlob(requestObject.body);
+  return new Response(decryptedBlob);
 };
 
 export const put = async (
@@ -24,5 +42,6 @@ export const put = async (
   response: Response
 ): Promise<void> => {
   const body = await response.clone().blob();
-  return await add("cachedResponses", urlOf(request), body);
+  const encryptedBlob = await encryptBlob(body);
+  return await add("cachedResponses", urlOf(request), encryptedBlob);
 };


### PR DESCRIPTION
A demo using the SimpleCrypto module to encrypt/decrypt pages when they go into the IDB cache.

This is good enough to merge, as even though it's not secure, it does at least obfuscate the plain text IDB cache.