### PR TITLE
Set all pages to Cache-Control no-store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  before_action :set_disable_cache_headers
+
   if Rails.env.production?
     http_basic_authenticate_with name: Settings.support_username,
                                  password: Settings.support_password,
@@ -7,4 +9,12 @@ class ApplicationController < ActionController::Base
   end
 
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
+
+  private
+
+  def set_disable_cache_headers
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+  end
 end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -4,7 +4,6 @@ class VaccinationsController < ApplicationController
   before_action :set_children, only: %i[index record_template]
 
   def index
-    set_disable_cache_headers
     respond_to do |format|
       format.html
       format.json { render json: @children.index_by(&:id) }
@@ -74,11 +73,5 @@ class VaccinationsController < ApplicationController
 
   def set_children
     @children = @campaign.children.order(:first_name, :last_name)
-  end
-
-  def set_disable_cache_headers
-    response.headers["Cache-Control"] = "no-store"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "0"
   end
 end


### PR DESCRIPTION
Without this, the browser can choose to temporarily store pages in the user's navigation in a client-side plaintext cache. Because our pages can contain things like NHS numbers or user data, this is a potential security risk.

There's no tests in this commit because `spec/requests/pages_spec.rb` covered testing the `/children.json` endpoint, and it should still pass.