### PR TITLE
Don't swallow `put` errors in NetworkFirst strategy

### DIFF
--- a/app/javascript/serviceworker/network.ts
+++ b/app/javascript/serviceworker/network.ts
@@ -6,10 +6,11 @@ export const cacheOnly = async (request: Request): Promise<Response> => {
 
 export const networkFirst = async (request: Request): Promise<Response> => {
   try {
-    const networkResponse = await fetch(request);
-    await put(request, networkResponse.clone());
-    return networkResponse;
+    var networkResponse = await fetch(request);
   } catch (err) {
     return cacheOnly(request);
   }
+
+  await put(request, networkResponse.clone());
+  return networkResponse;
 };


### PR DESCRIPTION
We need to pull out the `put` call from the try.