### PR TITLE
Add wait to offline test

### DIFF
--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -34,6 +34,9 @@ test("Works offline", async ({ page, context }) => {
 
   await page.getByTestId("save-offline").click();
 
+  // Wait for all the requests to finish and be cached
+  await page.waitForTimeout(100);
+
   await goOffline();
 
   await page.getByTestId("record").click();


### PR DESCRIPTION
When clicking "Save offline," 5 or so requests are queued from the server. If we immediately switch the server to offline, those requests might still be in flight. We could use the `swWaitForRequest` function with a loop of all the possible requests to wait for them, or we could just add a 100ms timeout, which seems simpler.

This is a temporary measure to fix flaky tests on the `main` branch and will be replaced by a different offline e2e test, once we switch to the password-based implementation.