### PR TITLE
Keep service worker alive

### DIFF
--- a/app/javascript/serviceworker-companion.js
+++ b/app/javascript/serviceworker-companion.js
@@ -2,9 +2,19 @@ import { Workbox } from "workbox-window";
 
 export let wb;
 
+const keepServiceWorkerAlive = () => {
+  setInterval(() => {
+    wb.messageSW({
+      type: "GET_CONNECTION_STATUS",
+    });
+  }, 20 * 1000);
+};
+
 export function initServiceWorker() {
   if ("serviceWorker" in navigator) {
     wb = new Workbox("/sw.js");
     wb.register();
+
+    keepServiceWorkerAlive();
   }
 }


### PR DESCRIPTION
ServiceWorkers are designed to go to sleep after 30 seconds of inactivity, to preserve memory and battery.

For our application, we need the ServiceWorker to stay alive once the user has initialised the encryption secret, so that the secret stays in memory. Otherwise, when offline working, if they don't touch the browser tab for 30 seconds, we'd have to ask them for the password again.

To work around this, we can force the service worker to stay alive by pinging it every 20 seconds.

In my testing, this seems to work consistently in Firefox (devtools opened or not), and inconsistently in Chrome-based browsers.

As this is imperfect, it's optional to merge and I extracted it from the main offline password PR. It makes offline working a little more reliable, but we'll have to replace this with a better implementation.