### PR TITLE
Disable implicit offline caching

### DIFF
--- a/app/javascript/controllers/offline_campaign_controller.js
+++ b/app/javascript/controllers/offline_campaign_controller.js
@@ -6,9 +6,14 @@ export default class extends Controller {
   connect() {}
 
   saveOffline() {
+    // Pass in paths to CSS and JS to save for offline use, because document
+    // methods are not available in serviceWorker
+    const css = document.querySelector("link[rel=stylesheet]").href;
+    const js = document.querySelector("script[src]").src;
+
     wb.messageSW({
       type: "SAVE_CAMPAIGN_FOR_OFFLINE",
-      payload: { campaignId: 1 },
+      payload: { campaignId: 1, additionalItems: [css, js] },
     });
   }
 }

--- a/app/javascript/serviceworker/messages.js
+++ b/app/javascript/serviceworker/messages.js
@@ -14,6 +14,10 @@ const messageHandlers = {
     const campaignId = data.payload["campaignId"];
 
     addAll([
+      ...data.payload["additionalItems"],
+      `/favicon.ico`,
+      `/dashboard`,
+      `/campaigns/${campaignId}`,
       `/campaigns/${campaignId}/children`,
       `/campaigns/${campaignId}/children.json`,
       `/campaigns/${campaignId}/children/record-template`,

--- a/app/javascript/serviceworker/messages.spec.js
+++ b/app/javascript/serviceworker/messages.spec.js
@@ -32,13 +32,22 @@ describe("messageHandler", () => {
 
   describe("SAVE_CAMPAIGN_FOR_OFFLINE", () => {
     test("works", () => {
-      handler(event("SAVE_CAMPAIGN_FOR_OFFLINE", ["1"]));
+      handler(
+        event("SAVE_CAMPAIGN_FOR_OFFLINE", {
+          campaignId: 1,
+          additionalItems: ["/assets/application.js"],
+        })
+      );
       expect(addAll.mock.calls[0][0]).toMatchInlineSnapshot(`
         [
-          "/campaigns/undefined/children",
-          "/campaigns/undefined/children.json",
-          "/campaigns/undefined/children/record-template",
-          "/campaigns/undefined/children/show-template",
+          "/assets/application.js",
+          "/favicon.ico",
+          "/dashboard",
+          "/campaigns/1",
+          "/campaigns/1/children",
+          "/campaigns/1/children.json",
+          "/campaigns/1/children/record-template",
+          "/campaigns/1/children/show-template",
         ]
       `);
     });

--- a/app/javascript/serviceworker/network.spec.ts
+++ b/app/javascript/serviceworker/network.spec.ts
@@ -1,6 +1,6 @@
 require("jest-fetch-mock").enableMocks();
 import { cacheOnly, networkFirst } from "./network";
-import { match, put } from "./cache";
+import { match } from "./cache";
 
 jest.mock("./cache");
 
@@ -20,7 +20,6 @@ describe("networkFirst", () => {
     const request = new Request("https://example.com/test");
     const response = await networkFirst(request);
 
-    expect(put).toHaveBeenCalled();
     expect(response).toHaveProperty("status", 200);
   });
 

--- a/app/javascript/serviceworker/network.ts
+++ b/app/javascript/serviceworker/network.ts
@@ -1,4 +1,4 @@
-import { match, put } from "./cache";
+import { match } from "./cache";
 
 export const cacheOnly = async (request: Request): Promise<Response> => {
   return await match(request);
@@ -11,6 +11,5 @@ export const networkFirst = async (request: Request): Promise<Response> => {
     return cacheOnly(request);
   }
 
-  await put(request, networkResponse.clone());
   return networkResponse;
 };

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: campaigns
+#
+#  id            :bigint           not null, primary key
+#  date          :datetime
+#  location_type :text
+#  type          :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  location_id   :integer
+#
 FactoryBot.define do
   factory :campaign do
     date { Time.zone.today }

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: children
+#
+#  id             :bigint           not null, primary key
+#  consent        :integer
+#  dob            :date
+#  first_name     :text
+#  gp             :integer
+#  last_name      :text
+#  nhs_number     :bigint
+#  preferred_name :text
+#  screening      :integer
+#  seen           :integer
+#  sex            :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_children_on_nhs_number  (nhs_number) UNIQUE
+#
 FactoryBot.define do
   factory :child do
     nhs_number { rand(10**10) }

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: schools
+#
+#  id            :bigint           not null, primary key
+#  address       :text
+#  county        :text
+#  detailed_type :text
+#  locality      :text
+#  maximum_age   :decimal(, )
+#  minimum_age   :decimal(, )
+#  name          :text
+#  phase         :integer
+#  postcode      :text
+#  town          :text
+#  type          :text
+#  url           :text
+#  urn           :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_schools_on_urn  (urn) UNIQUE
+#
 FactoryBot.define do
   factory :school do
     name { Faker::Educator.primary_school }


### PR DESCRIPTION
Prerequisite for: https://github.com/nhsuk/record-childrens-vaccinations/pull/198

Depends on https://github.com/nhsuk/record-childrens-vaccinations/pull/200 (roughly... it might be mergeable without, but because this piles on additional requests in the `addAll`, the test just becomes even flakier without it).

The key bit in this PR is removing the `await put(request, networkResponse.clone());` call in the `NetworkFirst` strategy.

By doing this, pages are no longer cached implicitly, but instead have to be cached *explicitly*, via the "Save offline" button. The button is also updated to cache the JS and CSS alongside some other pages.

There's also a random "annotate" commit thrown in, I didn't want to split it off as its own PR, but it's harmless.

Disabling implicit offline caching is a necessary prerequisite to switching to using a user-provided password as the encryption key for the offline cache. We can't cache things before the user gives us that key.