### PR TITLE
Fix empty flash message when updating a record

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -27,8 +27,10 @@ class VaccinationsController < ApplicationController
         )
       imm.immunization.create # rubocop:disable Rails/SaveBang
     end
-    flash[:success] = { title: "Record saved" }
-    redirect_to campaign_vaccinations_path(@campaign)
+    redirect_to campaign_vaccinations_path(@campaign),
+                flash: {
+                  success: "Record saved"
+                }
   end
 
   def history

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -1,8 +1,10 @@
 <% if flash[:success].present? %>
   <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% nb.with_heading(text: flash[:success][:title]) %>
-    <% if flash[:success][:body].present? %>
+    <% if flash[:success].is_a?(Hash) %>
+      <% nb.with_heading(text: flash[:success][:title]) %>
       <p><%= flash[:success][:body] %></p>
+    <% else %>
+      <% nb.with_heading(text: flash[:success]) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Flashes oddly can only be a string if you're using `redirect_to`, but they can be hashes if you `render`.

### Before, vaccinating online

![image](https://user-images.githubusercontent.com/1650875/236473556-87ba8867-1ab1-43c8-9b45-b596e6d930bb.png)

### After, vaccinating online

![image](https://user-images.githubusercontent.com/1650875/236473503-535571ea-7fa3-4d5e-8ac0-16695031a963.png)
