### PR TITLE
Remove URL from staging database config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -63,7 +63,6 @@ test:
 staging:
   <<: *default
   database: record_childrens_vaccinations_staging
-  url: <%= ENV.fetch("DATABASE_URL") %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
This isn't necessary and breaks when running `bin/setup` locally unless DATABASE_URL is defined.