### PR TITLE
Add backend admin using Avo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.2.0"
 gem "rails", "~> 7.0.5"
 
+gem "avo"
 gem "awesome_print"
 gem "bootsnap", require: false
 gem "config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     activejob (7.0.5)
       activesupport (= 7.0.5)
       globalid (>= 0.3.6)
@@ -80,6 +83,20 @@ GEM
     asciidoctor-diagram-ditaamini (1.0.3)
     asciidoctor-diagram-plantuml (1.2023.5)
     ast (2.4.2)
+    avo (2.34.0)
+      actionview (>= 6.0)
+      active_link_to
+      activerecord (>= 6.0)
+      addressable
+      docile
+      dry-initializer
+      httparty
+      inline_svg
+      meta-tags
+      pagy
+      turbo-rails
+      view_component (>= 2.54.0)
+      zeitwerk (>= 2.6.2)
     awesome_print (1.9.2)
     backport (1.2.0)
     bcp47 (0.3.3)
@@ -118,6 +135,7 @@ GEM
       reline (>= 0.3.1)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dockerfile-rails (1.4.1)
       rails
     domain_name (0.5.20190701)
@@ -219,8 +237,14 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    inline_svg (1.9.0)
+      activesupport (>= 3.0)
+      nokogiri (>= 1.6)
     io-console (0.6.0)
     irb (1.6.4)
       reline (>= 0.3.0)
@@ -246,6 +270,8 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.18.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -470,6 +496,7 @@ DEPENDENCIES
   annotate
   asciidoctor
   asciidoctor-diagram
+  avo
   awesome_print
   bootsnap
   capybara

--- a/app/avo/resources/campaign_resource.rb
+++ b/app/avo/resources/campaign_resource.rb
@@ -1,13 +1,14 @@
 class CampaignResource < Avo::BaseResource
   self.title = :name
   self.includes = []
+  self.record_selector = false
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   # end
 
   field :id, as: :id
   # Fields generated from the model
-  field :name, as: :text
+  field :name, as: :text, required: true
   field :sessions, as: :has_many
   # add fields here
 end

--- a/app/avo/resources/campaign_resource.rb
+++ b/app/avo/resources/campaign_resource.rb
@@ -1,5 +1,5 @@
 class CampaignResource < Avo::BaseResource
-  self.title = :id
+  self.title = :name
   self.includes = []
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)

--- a/app/avo/resources/campaign_resource.rb
+++ b/app/avo/resources/campaign_resource.rb
@@ -8,7 +8,7 @@ class CampaignResource < Avo::BaseResource
 
   field :id, as: :id
   # Fields generated from the model
-  field :name, as: :text, required: true
+  field :name, as: :text
   field :sessions, as: :has_many
   # add fields here
 end

--- a/app/avo/resources/campaign_resource.rb
+++ b/app/avo/resources/campaign_resource.rb
@@ -1,0 +1,13 @@
+class CampaignResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :name, as: :text
+  field :sessions, as: :has_many
+  # add fields here
+end

--- a/app/avo/resources/child_resource.rb
+++ b/app/avo/resources/child_resource.rb
@@ -1,22 +1,23 @@
 class ChildResource < Avo::BaseResource
   self.title = :full_name
   self.includes = []
+  self.record_selector = false
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   # end
 
   field :id, as: :id
   # Fields generated from the model
-  field :dob, as: :date
-  field :nhs_number, as: :number
+  field :dob, as: :date, required: true
+  field :nhs_number, as: :number, required: true
   field :sex, as: :select, enum: ::Child.sexes
-  field :first_name, as: :text
-  field :last_name, as: :text
+  field :first_name, as: :text, required: true
+  field :last_name, as: :text, required: true
   field :preferred_name, as: :text
-  field :gp, as: :select, enum: ::Child.gps
-  field :screening, as: :select, enum: ::Child.screenings
-  field :consent, as: :select, enum: ::Child.consents
-  field :seen, as: :select, enum: ::Child.seens
+  field :gp, as: :select, enum: ::Child.gps, required: true
+  field :screening, as: :select, enum: ::Child.screenings, required: true
+  field :consent, as: :select, enum: ::Child.consents, required: true
+  field :seen, as: :select, enum: ::Child.seens, required: true
   field :sessions, as: :has_and_belongs_to_many
   field :location, as: :belongs_to
   # add fields here

--- a/app/avo/resources/child_resource.rb
+++ b/app/avo/resources/child_resource.rb
@@ -1,0 +1,23 @@
+class ChildResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :dob, as: :date
+  field :nhs_number, as: :number
+  field :sex, as: :select, enum: ::Child.sexes
+  field :first_name, as: :textarea
+  field :last_name, as: :textarea
+  field :preferred_name, as: :textarea
+  field :gp, as: :select, enum: ::Child.gps
+  field :screening, as: :select, enum: ::Child.screenings
+  field :consent, as: :select, enum: ::Child.consents
+  field :seen, as: :select, enum: ::Child.seens
+  field :sessions, as: :has_and_belongs_to_many
+  field :location, as: :belongs_to
+  # add fields here
+end

--- a/app/avo/resources/child_resource.rb
+++ b/app/avo/resources/child_resource.rb
@@ -1,5 +1,5 @@
 class ChildResource < Avo::BaseResource
-  self.title = :id
+  self.title = :full_name
   self.includes = []
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
@@ -10,9 +10,9 @@ class ChildResource < Avo::BaseResource
   field :dob, as: :date
   field :nhs_number, as: :number
   field :sex, as: :select, enum: ::Child.sexes
-  field :first_name, as: :textarea
-  field :last_name, as: :textarea
-  field :preferred_name, as: :textarea
+  field :first_name, as: :text
+  field :last_name, as: :text
+  field :preferred_name, as: :text
   field :gp, as: :select, enum: ::Child.gps
   field :screening, as: :select, enum: ::Child.screenings
   field :consent, as: :select, enum: ::Child.consents

--- a/app/avo/resources/child_resource.rb
+++ b/app/avo/resources/child_resource.rb
@@ -8,16 +8,16 @@ class ChildResource < Avo::BaseResource
 
   field :id, as: :id
   # Fields generated from the model
-  field :dob, as: :date, required: true
-  field :nhs_number, as: :number, required: true
-  field :sex, as: :select, enum: ::Child.sexes
-  field :first_name, as: :text, required: true
-  field :last_name, as: :text, required: true
+  field :first_name, as: :text
+  field :last_name, as: :text
   field :preferred_name, as: :text
-  field :gp, as: :select, enum: ::Child.gps, required: true
-  field :screening, as: :select, enum: ::Child.screenings, required: true
-  field :consent, as: :select, enum: ::Child.consents, required: true
-  field :seen, as: :select, enum: ::Child.seens, required: true
+  field :dob, as: :date
+  field :nhs_number, as: :number
+  field :sex, as: :select, enum: ::Child.sexes
+  field :gp, as: :select, enum: ::Child.gps
+  field :screening, as: :select, enum: ::Child.screenings
+  field :consent, as: :select, enum: ::Child.consents
+  field :seen, as: :select, enum: ::Child.seens
   field :sessions, as: :has_and_belongs_to_many
   field :location, as: :belongs_to
   # add fields here

--- a/app/avo/resources/location_resource.rb
+++ b/app/avo/resources/location_resource.rb
@@ -1,13 +1,14 @@
 class LocationResource < Avo::BaseResource
   self.title = :name
   self.includes = []
+  self.record_selector = false
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   # end
 
   field :id, as: :id
   # Fields generated from the model
-  field :name, as: :text
+  field :name, as: :text, required: true
   field :address, as: :text
   field :locality, as: :text
   field :town, as: :text

--- a/app/avo/resources/location_resource.rb
+++ b/app/avo/resources/location_resource.rb
@@ -1,5 +1,5 @@
 class LocationResource < Avo::BaseResource
-  self.title = :id
+  self.title = :name
   self.includes = []
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
@@ -7,13 +7,13 @@ class LocationResource < Avo::BaseResource
 
   field :id, as: :id
   # Fields generated from the model
-  field :name, as: :textarea
-  field :address, as: :textarea
-  field :locality, as: :textarea
-  field :town, as: :textarea
-  field :county, as: :textarea
-  field :postcode, as: :textarea
-  field :url, as: :textarea
+  field :name, as: :text
+  field :address, as: :text
+  field :locality, as: :text
+  field :town, as: :text
+  field :county, as: :text
+  field :postcode, as: :text
+  field :url, as: :text
   field :sessions, as: :has_many
   field :children, as: :has_many
   # add fields here

--- a/app/avo/resources/location_resource.rb
+++ b/app/avo/resources/location_resource.rb
@@ -8,7 +8,7 @@ class LocationResource < Avo::BaseResource
 
   field :id, as: :id
   # Fields generated from the model
-  field :name, as: :text, required: true
+  field :name, as: :text
   field :address, as: :text
   field :locality, as: :text
   field :town, as: :text

--- a/app/avo/resources/location_resource.rb
+++ b/app/avo/resources/location_resource.rb
@@ -1,0 +1,20 @@
+class LocationResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :name, as: :textarea
+  field :address, as: :textarea
+  field :locality, as: :textarea
+  field :town, as: :textarea
+  field :county, as: :textarea
+  field :postcode, as: :textarea
+  field :url, as: :textarea
+  field :sessions, as: :has_many
+  field :children, as: :has_many
+  # add fields here
+end

--- a/app/avo/resources/session_resource.rb
+++ b/app/avo/resources/session_resource.rb
@@ -1,14 +1,15 @@
 class SessionResource < Avo::BaseResource
   self.title = :name
   self.includes = []
+  self.record_selector = false
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   # end
 
   field :id, as: :id
   # Fields generated from the model
-  field :date, as: :date_time
-  field :name, as: :text
+  field :name, as: :text, required: true
+  field :date, as: :date_time, required: true
   field :campaign, as: :belongs_to
   field :location, as: :belongs_to
   field :children, as: :has_and_belongs_to_many

--- a/app/avo/resources/session_resource.rb
+++ b/app/avo/resources/session_resource.rb
@@ -1,0 +1,18 @@
+class SessionResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :date, as: :date_time
+  field :location_id, as: :number
+  field :name, as: :textarea
+  field :campaign_id, as: :number
+  field :campaign, as: :belongs_to
+  field :location, as: :belongs_to
+  field :children, as: :has_and_belongs_to_many
+  # add fields here
+end

--- a/app/avo/resources/session_resource.rb
+++ b/app/avo/resources/session_resource.rb
@@ -1,5 +1,5 @@
 class SessionResource < Avo::BaseResource
-  self.title = :id
+  self.title = :name
   self.includes = []
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
@@ -8,9 +8,7 @@ class SessionResource < Avo::BaseResource
   field :id, as: :id
   # Fields generated from the model
   field :date, as: :date_time
-  field :location_id, as: :number
-  field :name, as: :textarea
-  field :campaign_id, as: :number
+  field :name, as: :text
   field :campaign, as: :belongs_to
   field :location, as: :belongs_to
   field :children, as: :has_and_belongs_to_many

--- a/app/avo/resources/session_resource.rb
+++ b/app/avo/resources/session_resource.rb
@@ -8,8 +8,8 @@ class SessionResource < Avo::BaseResource
 
   field :id, as: :id
   # Fields generated from the model
-  field :name, as: :text, required: true
-  field :date, as: :date_time, required: true
+  field :name, as: :text
+  field :date, as: :date_time
   field :campaign, as: :belongs_to
   field :location, as: :belongs_to
   field :children, as: :has_and_belongs_to_many

--- a/app/controllers/avo/campaigns_controller.rb
+++ b/app/controllers/avo/campaigns_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::CampaignsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/children_controller.rb
+++ b/app/controllers/avo/children_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::ChildrenController < Avo::ResourcesController
+end

--- a/app/controllers/avo/locations_controller.rb
+++ b/app/controllers/avo/locations_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::LocationsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/sessions_controller.rb
+++ b/app/controllers/avo/sessions_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::SessionsController < Avo::ResourcesController
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -9,4 +9,6 @@
 #
 class Campaign < ApplicationRecord
   has_many :sessions, dependent: :destroy
+
+  validates :name, presence: true
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -27,6 +27,13 @@ class Child < ApplicationRecord
   enum :consent, ["Parental consent (digital)"]
   enum :seen, ["Not yet", "Vaccinated"]
 
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :dob, presence: true
+  validates :nhs_number, presence: true, uniqueness: true
+  validates :gp, presence: true
+  validates :screening, presence: true
+
   has_and_belongs_to_many :sessions
   belongs_to :location, optional: true
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -16,4 +16,6 @@
 class Location < ApplicationRecord
   has_many :sessions
   has_many :children
+
+  validates :name, presence: true
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -19,6 +19,9 @@ class Session < ApplicationRecord
   belongs_to :location, optional: true
   has_and_belongs_to_many :children
 
+  validates :name, presence: true
+  validates :date, presence: true
+
   def type
     campaign.name
   end

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -1,0 +1,110 @@
+# For more information regarding these settings check out our docs https://docs.avohq.io
+Avo.configure do |config|
+  ## == Routing ==
+  config.root_path = '/avo'
+  # used only when you have custom `map` configuration in your config.ru
+  # config.prefix_path = "/internal"
+
+  # Where should the user be redirected when visting the `/avo` url
+  # config.home_path = nil
+
+  ## == Licensing ==
+  config.license = 'community' # change this to 'pro' when you add the license key
+  # config.license_key = ENV['AVO_LICENSE_KEY']
+
+  ## == Set the context ==
+  config.set_context do
+    # Return a context object that gets evaluated in Avo::ApplicationController
+  end
+
+  ## == Authentication ==
+  # config.current_user_method = {}
+  # config.authenticate_with do
+  # end
+
+  ## == Authorization ==
+  # config.authorization_methods = {
+  #   index: 'index?',
+  #   show: 'show?',
+  #   edit: 'edit?',
+  #   new: 'new?',
+  #   update: 'update?',
+  #   create: 'create?',
+  #   destroy: 'destroy?',
+  #   search: 'search?',
+  # }
+  # config.raise_error_on_missing_policy = false
+  # config.authorization_client = :pundit
+
+  ## == Localization ==
+  # config.locale = 'en-US'
+
+  ## == Resource options ==
+  # config.resource_controls_placement = :right
+  # config.model_resource_mapping = {}
+  # config.default_view_type = :table
+  # config.per_page = 24
+  # config.per_page_steps = [12, 24, 48, 72]
+  # config.via_per_page = 8
+  # config.id_links_to_resource = false
+  # config.cache_resources_on_index_view = true
+  ## permanent enable or disable cache_resource_filters, default value is false
+  # config.cache_resource_filters = false
+  ## provide a lambda to enable or disable cache_resource_filters per user/resource.
+  # config.cache_resource_filters = ->(current_user:, resource:) { current_user.cache_resource_filters?}
+
+  ## == Customization ==
+  # config.app_name = 'Avocadelicious'
+  # config.timezone = 'UTC'
+  # config.currency = 'USD'
+  # config.hide_layout_when_printing = false
+  # config.full_width_container = false
+  # config.full_width_index_view = false
+  # config.search_debounce = 300
+  # config.view_component_path = "app/components"
+  # config.display_license_request_timeout_error = true
+  # config.disabled_features = []
+  # config.tabs_style = :tabs # can be :tabs or :pills
+  # config.buttons_on_form_footers = true
+  # config.field_wrapper_layout = true
+
+  ## == Branding ==
+  # config.branding = {
+  #   colors: {
+  #     background: "248 246 242",
+  #     100 => "#CEE7F8",
+  #     400 => "#399EE5",
+  #     500 => "#0886DE",
+  #     600 => "#066BB2",
+  #   },
+  #   chart_colors: ["#0B8AE2", "#34C683", "#2AB1EE", "#34C6A8"],
+  #   logo: "/avo-assets/logo.png",
+  #   logomark: "/avo-assets/logomark.png",
+  #   placeholder: "/avo-assets/placeholder.svg",
+  #   favicon: "/avo-assets/favicon.ico"
+  # }
+
+  ## == Breadcrumbs ==
+  # config.display_breadcrumbs = true
+  # config.set_initial_breadcrumbs do
+  #   add_breadcrumb "Home", '/avo'
+  # end
+
+  ## == Menus ==
+  # config.main_menu = -> {
+  #   section "Dashboards", icon: "dashboards" do
+  #     all_dashboards
+  #   end
+
+  #   section "Resources", icon: "resources" do
+  #     all_resources
+  #   end
+
+  #   section "Tools", icon: "tools" do
+  #     all_tools
+  #   end
+  # }
+  # config.profile_menu = -> {
+  #   link "Profile", path: "/avo/profile", icon: "user-circle"
+  # }
+end

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -1,7 +1,7 @@
 # For more information regarding these settings check out our docs https://docs.avohq.io
 Avo.configure do |config|
   ## == Routing ==
-  config.root_path = '/avo'
+  config.root_path = "/avo"
   # used only when you have custom `map` configuration in your config.ru
   # config.prefix_path = "/internal"
 
@@ -9,7 +9,7 @@ Avo.configure do |config|
   # config.home_path = nil
 
   ## == Licensing ==
-  config.license = 'community' # change this to 'pro' when you add the license key
+  config.license = "community" # change this to 'pro' when you add the license key
   # config.license_key = ENV['AVO_LICENSE_KEY']
 
   ## == Set the context ==
@@ -18,9 +18,14 @@ Avo.configure do |config|
   end
 
   ## == Authentication ==
-  # config.current_user_method = {}
-  # config.authenticate_with do
-  # end
+  config.current_user_method do
+    Struct.new(:id, :name, :email, :avatar_url).new(
+      1,
+      "Demo Admin",
+      "admin@example.com",
+      "https://avo.app/images/avo-icon.png"
+    )
+  end
 
   ## == Authorization ==
   # config.authorization_methods = {

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -1,7 +1,7 @@
 # For more information regarding these settings check out our docs https://docs.avohq.io
 Avo.configure do |config|
   ## == Routing ==
-  config.root_path = "/avo"
+  config.root_path = "/model-office-admin"
   # used only when you have custom `map` configuration in your config.ru
   # config.prefix_path = "/internal"
 
@@ -21,9 +21,8 @@ Avo.configure do |config|
   config.current_user_method do
     Struct.new(:id, :name, :email, :avatar_url).new(
       1,
-      "Demo Admin",
-      "admin@example.com",
-      "https://avo.app/images/avo-icon.png"
+      "Model office admin",
+      "admin@example.com"
     )
   end
 
@@ -59,7 +58,7 @@ Avo.configure do |config|
   # config.cache_resource_filters = ->(current_user:, resource:) { current_user.cache_resource_filters?}
 
   ## == Customization ==
-  # config.app_name = 'Avocadelicious'
+  config.app_name = "Model office admin"
   # config.timezone = 'UTC'
   # config.currency = 'USD'
   # config.hide_layout_when_printing = false
@@ -76,17 +75,17 @@ Avo.configure do |config|
   ## == Branding ==
   # config.branding = {
   #   colors: {
-  #     background: "248 246 242",
+  #     :background => "248 246 242",
   #     100 => "#CEE7F8",
   #     400 => "#399EE5",
   #     500 => "#0886DE",
   #     600 => "#066BB2",
   #   },
-  #   chart_colors: ["#0B8AE2", "#34C683", "#2AB1EE", "#34C6A8"],
+  #   chart_colors: %w[#0B8AE2 #34C683 #2AB1EE #34C6A8],
   #   logo: "/avo-assets/logo.png",
   #   logomark: "/avo-assets/logomark.png",
   #   placeholder: "/avo-assets/placeholder.svg",
-  #   favicon: "/avo-assets/favicon.ico"
+  #   favicon: "/avo-assets/favicon.ico",
   # }
 
   ## == Breadcrumbs ==

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Avo::Engine, at: Avo.configuration.root_path
   root to: redirect("/start")
 
   get "/start", to: "pages#start"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  mount Avo::Engine, at: Avo.configuration.root_path
   root to: redirect("/start")
+
+  mount Avo::Engine, at: Avo.configuration.root_path
 
   get "/start", to: "pages#start"
   get "/dashboard", to: "dashboard#index"


### PR DESCRIPTION
[Avo](https://github.com/avo-hq/avo) is a Rails engine that provides a batteries-included Rails admin interface, to edit individual models or run rake tasks using a web interface.

Because we don't yet have Devise set up, or authorization, this PR includes a Demo Admin user stub.

Whenever a model is updated, we'll have to ensure the Avo resources are kept in sync with any new fields being added/removed.

TODO:

- [ ] Make sure it's hidden behind basic auth (separate from usual basic auth?)

### Example screenshots

#### Children index

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/143063cd-fd89-437a-8402-6435fb48c94c)

#### Children show

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/5e0b52f0-d4a0-4024-8fec-6f62fdad92f8)

#### Location edit

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/13cba776-e16e-4201-9a0d-258da7a971e5)

#### Sessions show

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/59e79dfc-41e6-4350-a460-077b7b7ee90a)
