### PR TITLE
Create PatientSession model

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -21,11 +21,9 @@
 #  index_patients_on_nhs_number  (nhs_number) UNIQUE
 #
 class Patient < ApplicationRecord
-  enum :sex, %w[Female Male]
-  enum :gp, ["Local GP"]
-  enum :screening, ["Approved for vaccination"]
-  enum :consent, ["Parental consent (digital)"]
-  enum :seen, ["Not yet", "Vaccinated"]
+  belongs_to :location, optional: true
+  has_many :patient_sessions
+  has_many :sessions, through: :patient_sessions
 
   validates :first_name, presence: true
   validates :last_name, presence: true
@@ -34,8 +32,11 @@ class Patient < ApplicationRecord
   validates :gp, presence: true
   validates :screening, presence: true
 
-  has_and_belongs_to_many :sessions
-  belongs_to :location, optional: true
+  enum :sex, %w[Female Male]
+  enum :gp, ["Local GP"]
+  enum :screening, ["Approved for vaccination"]
+  enum :consent, ["Parental consent (digital)"]
+  enum :seen, ["Not yet", "Vaccinated"]
 
   def full_name
     "#{first_name} #{last_name}"

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: patient_sessions
+#
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  patient_id :bigint           not null
+#  session_id :bigint           not null
+#
+# Indexes
+#
+#  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
+#  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#
+class PatientSession < ApplicationRecord
+  belongs_to :patient
+  belongs_to :session
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -17,7 +17,8 @@
 class Session < ApplicationRecord
   belongs_to :campaign
   belongs_to :location, optional: true
-  has_and_belongs_to_many :patients
+  has_many :patient_sessions
+  has_many :patients, through: :patient_sessions
 
   validates :name, presence: true
   validates :date, presence: true

--- a/db/migrate/20230609153358_rename_table_patients_sessions_to_patient_sessions.rb
+++ b/db/migrate/20230609153358_rename_table_patients_sessions_to_patient_sessions.rb
@@ -1,0 +1,7 @@
+class RenameTablePatientsSessionsToPatientSessions < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    rename_table :patients_sessions, :patient_sessions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_07_150942) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_09_153358) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_150942) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "patient_sessions", id: false, force: :cascade do |t|
+    t.bigint "session_id", null: false
+    t.bigint "patient_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["patient_id", "session_id"], name: "index_patient_sessions_on_patient_id_and_session_id", unique: true
+    t.index ["session_id", "patient_id"], name: "index_patient_sessions_on_session_id_and_patient_id", unique: true
+  end
+
   create_table "patients", force: :cascade do |t|
     t.date "dob"
     t.bigint "nhs_number"
@@ -52,15 +61,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_150942) do
     t.integer "consent"
     t.integer "seen"
     t.index ["nhs_number"], name: "index_patients_on_nhs_number", unique: true
-  end
-
-  create_table "patients_sessions", id: false, force: :cascade do |t|
-    t.bigint "session_id", null: false
-    t.bigint "patient_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["patient_id", "session_id"], name: "index_patients_sessions_on_patient_id_and_session_id", unique: true
-    t.index ["session_id", "patient_id"], name: "index_patients_sessions_on_session_id_and_patient_id", unique: true
   end
 
   create_table "sessions", force: :cascade do |t|


### PR DESCRIPTION
We'll need to record multiple vaccination outcomes per patient + session. To model this, we've decided to have a one-to-many relationship between patient_sessions and vaccination_records.

To create that relationship, Rails wants the PatientSession to be its own join model, rather than just a join table. We also have to explicitly add `has_many :patient_sessions` to the patient and session models.

This change does not affect the controller or view code at all, as its just plumbing to update the table name and to associate the models correctly.

Some enum/validations have been shuffled around, as I prefer putting all the relationships at the top of a model definition.

### Data model

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/7f54e11c-c6bc-4d05-9aeb-50784dbe6d2a)
