### PR TITLE
Update status tag component

### DIFF
--- a/app/components/app_status_tag_component.html.erb
+++ b/app/components/app_status_tag_component.html.erb
@@ -1,7 +1,7 @@
-<div class="<%= css_classes %>" style="width: 100%">
-  <% if svg_icon %>
-    <svg class="nhsuk-icon nhsuk-icon__<%= svg_icon %>" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <% if svg_icon == 'tick' %>
+<div <%= tag.attributes div_attributes %> style="width: 100%">
+  <% if icon %>
+    <svg class="nhsuk-icon nhsuk-icon__<%= icon %>" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <% if icon == 'tick' %>
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12" stroke="currentColor">
         </path>
       <% else %>
@@ -13,6 +13,6 @@
     </svg>
   <% end %>
   <span class="nhsuk-u-font-size-16">
-    <%= status_text %>
+    <%= status %>
   </span>
 </div>

--- a/app/components/app_status_tag_component.rb
+++ b/app/components/app_status_tag_component.rb
@@ -1,46 +1,33 @@
 class AppStatusTagComponent < ViewComponent::Base
-  def initialize(status:)
+  BASE_CLASSES = %w[app-status-tag nhsuk-tag].freeze
+
+  attr_reader :status, :colour, :icon
+
+  def initialize(status:, colour:, icon: nil)
     super
 
     @status = status
+    @colour = colour
+    @icon = icon
+    @classes = BASE_CLASSES
   end
 
-  def css_classes
-    base_classes = "app-status-tag nhsuk-tag"
-    status_classes = {
-      :no_outcome => " nhsuk-tag--white",
-      :vaccinated => " nhsuk-tag--green",
-      :no_consent => " nhsuk-tag--red",
-      :could_not_vaccinate => " nhsuk-tag--orange",
-      "Do not vaccinate" => " nhsuk-tag--red",
-      "Ready for session" => " nhsuk-tag--green",
-      "Needs follow up" => " nhsuk-tag--blue",
-      "To do" => " nhsuk-tag--grey",
-      "No response" => " nhsuk-tag--white"
-    }
-
-    base_classes +
-      (status_classes[@status] || raise("Unknown status: #{@status}"))
-  end
-
-  # Convert status symbols to text, if necessary
-  def status_text
-    status_texts = {
-      no_outcome: "No outcome yet",
-      vaccinated: "Vaccinated",
-      no_consent: "No consent",
-      could_not_vaccinate: "Could not vaccinate"
-    }
-
-    status_texts.fetch(@status, @status)
+  def css_class
+    {
+      white: ["nhsuk-tag--white"],
+      green: ["nhsuk-tag--green"],
+      red: ["nhsuk-tag--red"],
+      orange: ["nhsuk-tag--orange"],
+      blue: ["nhsuk-tag--blue"],
+      grey: ["nhsuk-tag--grey"]
+    }.fetch(@colour)
   end
 
   def svg_icon
-    case @status
-    when :vaccinated, "Ready for session"
-      "tick"
-    when :no_consent, :could_not_vaccinate, "Do not vaccinate"
-      "cross"
-    end
+    return @icon if @icon
+  end
+
+  def div_attributes
+    { class: @classes + css_class }
   end
 end

--- a/app/helpers/triage_helper.rb
+++ b/app/helpers/triage_helper.rb
@@ -1,0 +1,27 @@
+module TriageHelper
+  def triage_status_colour(status)
+    case status
+    when "do_not_vaccinate"
+      :red
+    when "ready_for_session"
+      :green
+    when "needs_follow_up"
+      :blue
+    when "to_do"
+      :grey
+    when "no_response"
+      :white
+    else
+      :white
+    end
+  end
+
+  def triage_status_icon(status)
+    case status
+    when "do_not_vaccinate"
+      "cross"
+    when "ready_for_session"
+      "tick"
+    end
+  end
+end

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -1,2 +1,25 @@
 module VaccinationsHelper
+  def vaccination_status_colour(status)
+    case status
+    when "no_outcome"
+      :white
+    when "vaccinated"
+      :green
+    when "no_consent"
+      :red
+    when "could_not_vaccinate"
+      :orange
+    else
+      :white
+    end
+  end
+
+  def vaccination_status_icon(status)
+    case status
+    when "no_consent", "couldnt_vaccinate"
+      "cross"
+    when "vaccinated"
+      "tick"
+    end
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,10 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  def self.human_enum_name(enum_name, enum_value)
+    enum_i18n_key = enum_name.to_s.pluralize
+    I18n.t(
+      "activerecord.attributes.#{model_name.i18n_key}.#{enum_i18n_key}.#{enum_value}"
+    )
+  end
 end

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -20,6 +20,6 @@ class Triage < ApplicationRecord
   belongs_to :patient
 
   enum :status,
-       ["To do", "Ready for session", "Do not vaccinate", "Needs follow up"],
-       default: "To do"
+       %i[to_do ready_for_session do_not_vaccinate needs_follow_up],
+       default: :to_do
 end

--- a/app/views/triage/_patient_row.html.erb
+++ b/app/views/triage/_patient_row.html.erb
@@ -6,6 +6,8 @@
     <%= "Notes from nurse" if triage.notes.present? %>
   </td>
   <td class="govuk-table__cell">
-    <%= render(AppStatusTagComponent.new(status: triage.status )) %>
+    <%= render(AppStatusTagComponent.new(status: Triage.human_enum_name(:status, triage.status),
+                                         colour: triage_status_colour(triage.status),
+                                         icon: triage_status_icon(triage.status))) %>
   </td>
 </tr>

--- a/app/views/vaccinations/_patient_row.html.erb
+++ b/app/views/vaccinations/_patient_row.html.erb
@@ -10,6 +10,8 @@
     <%= patient.consent %>
   </td>
   <td class="govuk-table__cell" data-testid="child-status">
-    <%= render(AppStatusTagComponent.new(status: outcome)) %>
+    <%= render(AppStatusTagComponent.new(status: PatientSession.human_enum_name("outcome", outcome),
+                                         colour: vaccination_status_colour(outcome),
+                                         icon: vaccination_status_icon(outcome))) %>
   </td>
 </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,12 @@ en:
           no_outcome: No outcome yet
           no_consent: No consent
           vaccinated: Vaccinated
+      triage:
+        statuses:
+          to_do: To do
+          ready_for_session: Ready for session
+          do_not_vaccinate: Do not vaccinate
+          needs_follow_up: Needs follow up
     errors:
       models:
         offline_password:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,13 @@ en:
     name: Record children’s vaccinations
     email: my-service@email
   activerecord:
+    attributes:
+      patient_session:
+        outcomes:
+          could_not_vaccinate: Could not vaccinate
+          no_outcome: No outcome yet
+          no_consent: No consent
+          vaccinated: Vaccinated
     errors:
       models:
         offline_password:

--- a/db/sample_data/example-campaign.json
+++ b/db/sample_data/example-campaign.json
@@ -92,7 +92,7 @@
         "classes": "nhsuk-tag--grey"
       },
       "triage": {
-        "status": "Ready for session"
+        "status": "ready_for_session"
       }
     },
     {
@@ -120,7 +120,7 @@
         "classes": "nhsuk-tag--grey"
       },
       "triage": {
-        "status": "Ready for session",
+        "status": "ready_for_session",
         "notes": "Spoke with parent, it is safe to vaccinate"
       }
     },
@@ -149,7 +149,7 @@
         "classes": "nhsuk-tag--grey"
       },
       "triage": {
-        "status": "Do not vaccinate"
+        "status": "do_not_vaccinate"
       }
     },
     {
@@ -178,7 +178,7 @@
         "classes": "nhsuk-tag--grey"
       },
       "triage": {
-        "status": "Do not vaccinate",
+        "status": "do_not_vaccinate",
         "notes": "Spoke with parent, child has had the vaccine"
       }
     },
@@ -207,7 +207,7 @@
         "classes": "nhsuk-tag--grey"
       },
       "triage": {
-        "status": "Needs follow up"
+        "status": "needs_follow_up"
       }
     },
     {

--- a/spec/components/app_status_tag_component_spec.rb
+++ b/spec/components/app_status_tag_component_spec.rb
@@ -1,87 +1,35 @@
 require "rails_helper"
 
 RSpec.describe AppStatusTagComponent, type: :component do
-  let(:status) { :no_outcome }
-  let(:component) { render_inline(described_class.new(status:)) }
+  before { render_inline(component) }
 
-  context "when status is :no_outcome" do
-    it "renders no_outcome css class" do
-      expect(
-        component.css(".app-status-tag.nhsuk-tag.nhsuk-tag--white")
-      ).to be_present
-    end
+  subject { page }
 
-    it "renders no status text" do
-      expect(component.text).to include("No outcome yet")
-    end
+  let(:component) { described_class.new(status:, colour:, icon:) }
 
-    it "does not render svg icon" do
-      expect(component.css("svg")).to be_empty
-    end
-  end
+  let(:colour) { :white }
+  let(:status) { :test_status }
+  let(:icon) { nil }
 
-  context "when status is :vaccinated" do
-    let(:status) { :vaccinated }
+  %i[white green red orange blue grey].each do |colour|
+    context "when colour is #{colour}" do
+      let(:colour) { colour }
 
-    it "renders vaccinated css class" do
-      expect(
-        component.css(".app-status-tag.nhsuk-tag.nhsuk-tag--green")
-      ).to be_present
-    end
-
-    it "renders vaccinated text" do
-      expect(component.text).to include("Vaccinated")
-    end
-
-    it "renders tick svg icon" do
-      expect(component.css(".nhsuk-icon__tick")).to be_present
+      it { should have_css(".app-status-tag.nhsuk-tag.nhsuk-tag--#{colour}") }
     end
   end
 
-  context "when status is :no_consent" do
-    let(:status) { :no_consent }
+  %i[tick cross].each do |icon|
+    context "when icon is #{icon}" do
+      let(:icon) { icon }
 
-    it "renders no_consent css class" do
-      expect(
-        component.css(".app-status-tag.nhsuk-tag.nhsuk-tag--red")
-      ).to be_present
-    end
-
-    it "renders no consent text" do
-      expect(component.text).to include("No consent")
-    end
-
-    it "renders cross svg icon" do
-      expect(component.css(".nhsuk-icon__cross")).to be_present
+      it { should have_css(".nhsuk-icon__#{icon}") }
     end
   end
 
-  context "when status is :could_not_vaccinate" do
-    let(:status) { :could_not_vaccinate }
+  context "when icon is nil" do
+    let(:icon) { nil }
 
-    it "renders could_not_vaccinate css class" do
-      expect(
-        component.css(".app-status-tag.nhsuk-tag.nhsuk-tag--orange")
-      ).to be_present
-    end
-
-    it "renders could not vaccinate text" do
-      expect(component.text).to include("Could not vaccinate")
-    end
-
-    it "renders cross svg icon" do
-      expect(component.css(".nhsuk-icon__cross")).to be_present
-    end
-  end
-
-  context "when status is unknown" do
-    let(:status) { :unknown }
-
-    it "raises an error" do
-      expect { component }.to raise_error(
-        RuntimeError,
-        "Unknown status: unknown"
-      )
-    end
+    it { should_not have_css(".nhsuk-icon") }
   end
 end


### PR DESCRIPTION
Refactoring of the status tag component to be less use-case specific. This was done to make it easier to add pages like the triage index.