### PR TITLE
Add triage form

### DIFF
--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -33,7 +33,7 @@ class TriageController < ApplicationController
   end
 
   def set_triage
-    @triage = @patient.triage_for_campaign(@session.campaign)
+    @triage = @patient.triage_for_campaign(@session.campaign) || Triage.new
   end
 
   def set_consent_response

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -1,6 +1,6 @@
 class TriageController < ApplicationController
-  before_action :set_session, only: %i[index show]
-  before_action :set_patient, only: [:show]
+  before_action :set_session, only: %i[index show create]
+  before_action :set_patient, only: %i[show create]
   before_action :set_triage, only: [:show]
   before_action :set_consent_response, only: [:show]
 
@@ -22,6 +22,12 @@ class TriageController < ApplicationController
   def show
   end
 
+  def create
+    @triage = Triage.new(campaign: @session.campaign)
+    @triage.update!(triage_params)
+    redirect_to session_triage_index_path(@session)
+  end
+
   private
 
   def set_session
@@ -33,11 +39,17 @@ class TriageController < ApplicationController
   end
 
   def set_triage
-    @triage = @patient.triage_for_campaign(@session.campaign) || Triage.new
+    @triage =
+      @patient.triage_for_campaign(@session.campaign) ||
+        Triage.new(campaign: @session.campaign, patient: @patient)
   end
 
   def set_consent_response
     @consent_response =
       @patient.consent_response_for_campaign(@session.campaign)
+  end
+
+  def triage_params
+    params.require(:triage).permit(:patient_id, :status, :notes)
   end
 end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -25,14 +25,20 @@ class TriageController < ApplicationController
 
   def create
     @triage = Triage.new(campaign: @session.campaign, patient: @patient)
-    @triage.update!(triage_params)
-    redirect_to triage_session_path(@session)
+    if @triage.update(triage_params)
+      redirect_to triage_session_path(@session)
+    else
+      render :show, status: :unprocessable_entity
+    end
   end
 
   def update
     @triage = @patient.triage_for_campaign(@session.campaign)
-    @triage.update!(triage_params)
-    redirect_to triage_session_path(@session)
+    if @triage.update(triage_params)
+      redirect_to triage_session_path(@session)
+    else
+      render :show, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -4,6 +4,8 @@ class TriageController < ApplicationController
   before_action :set_triage, only: %i[show]
   before_action :set_consent_response, only: %i[show]
 
+  layout "two_thirds", except: %i[index]
+
   def index
     @session = Session.find_by(id: params[:id])
     @patient_triages =

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -1,10 +1,11 @@
 class TriageController < ApplicationController
-  before_action :set_session, only: %i[index show create]
+  before_action :set_session, only: %i[show create]
   before_action :set_patient, only: %i[show create]
-  before_action :set_triage, only: [:show]
-  before_action :set_consent_response, only: [:show]
+  before_action :set_triage, only: %i[show]
+  before_action :set_consent_response, only: %i[show]
 
   def index
+    @session = Session.find_by(id: params[:id])
     @patient_triages =
       @session
         .patients
@@ -23,9 +24,9 @@ class TriageController < ApplicationController
   end
 
   def create
-    @triage = Triage.new(campaign: @session.campaign)
+    @triage = Triage.new(campaign: @session.campaign, patient: @patient)
     @triage.update!(triage_params)
-    redirect_to session_triage_index_path(@session)
+    redirect_to triage_session_path(@session)
   end
 
   private
@@ -35,7 +36,7 @@ class TriageController < ApplicationController
   end
 
   def set_patient
-    @patient = Patient.find_by(id: params[:id])
+    @patient = @session.patients.find_by(id: params[:patient_id])
   end
 
   def set_triage
@@ -50,6 +51,6 @@ class TriageController < ApplicationController
   end
 
   def triage_params
-    params.require(:triage).permit(:patient_id, :status, :notes)
+    params.require(:triage).permit(:status, :notes)
   end
 end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -1,6 +1,6 @@
 class TriageController < ApplicationController
-  before_action :set_session, only: %i[show create]
-  before_action :set_patient, only: %i[show create]
+  before_action :set_session, only: %i[show create update]
+  before_action :set_patient, only: %i[show create update]
   before_action :set_triage, only: %i[show]
   before_action :set_consent_response, only: %i[show]
 
@@ -25,6 +25,12 @@ class TriageController < ApplicationController
 
   def create
     @triage = Triage.new(campaign: @session.campaign, patient: @patient)
+    @triage.update!(triage_params)
+    redirect_to triage_session_path(@session)
+  end
+
+  def update
+    @triage = @patient.triage_for_campaign(@session.campaign)
     @triage.update!(triage_params)
     redirect_to triage_session_path(@session)
   end

--- a/app/helpers/triage_helper.rb
+++ b/app/helpers/triage_helper.rb
@@ -5,9 +5,8 @@ module TriageHelper
       do_not_vaccinate: :red,
       needs_follow_up: :blue,
       no_response: :white,
-      ready_for_session: :green,
-      to_do: :grey
-    }.with_indifferent_access.fetch(triage_status)
+      ready_for_session: :green
+    }.with_indifferent_access.fetch(triage_status, :grey)
   end
 
   def triage_status_icon(triage_status:)
@@ -28,6 +27,12 @@ module TriageHelper
         "parent_relationship",
         consent_response.parent_relationship
       )
+    end
+  end
+
+  def triage_form_status_options
+    Triage.statuses.keys.map do |status|
+      [status, Triage.human_enum_name(:status, status)]
     end
   end
 end

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -19,7 +19,5 @@ class Triage < ApplicationRecord
   belongs_to :campaign
   belongs_to :patient
 
-  enum :status,
-       %i[to_do ready_for_session do_not_vaccinate needs_follow_up],
-       default: :to_do
+  enum :status, %i[ready_for_session do_not_vaccinate needs_follow_up]
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,11 +47,11 @@
       </div>
     </header>
 
-    <%= yield :before_main %>
-
     <div class="nhsuk-width-container">
+      <%= yield :before_main %>
+
       <main class="nhsuk-main-wrapper" id="main-content" role="main">
-        <%= yield %>
+        <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
 
       <%= render "layouts/toggle_offline" %>

--- a/app/views/layouts/two_thirds.html.erb
+++ b/app/views/layouts/two_thirds.html.erb
@@ -1,0 +1,11 @@
+<% content_for :content do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= yield :before_content %>
+
+      <%= yield %>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: 'layouts/application' %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -17,7 +17,7 @@
     <div class="nhsuk-card">
       <div class="nhsuk-card__content">
         <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
-          <%= link_to "Triage", session_triage_index_path(@session) %>
+          <%= link_to "Triage", triage_session_path(@session) %>
         </h2>
         <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
           <%= link_to "Record vaccinations", session_vaccinations_path(@session) %>

--- a/app/views/triage/_patient_row.html.erb
+++ b/app/views/triage/_patient_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <%= link_to patient.full_name, session_triage_path(@session, patient), "data-testid": "child-link" %>
+    <%= link_to patient.full_name, session_patient_triage_path(@session, patient), "data-testid": "child-link" %>
   </td>
   <td class="govuk-table__cell">
     <%= "Notes from nurse" if triage&.notes.present? %>

--- a/app/views/triage/_patient_triage.html.erb
+++ b/app/views/triage/_patient_triage.html.erb
@@ -22,5 +22,7 @@
       </div>
     </div>
 
+    <%= render "patient_triage_card", session: @session, triage: @triage %>
+
   </div>
 </div>

--- a/app/views/triage/_patient_triage.html.erb
+++ b/app/views/triage/_patient_triage.html.erb
@@ -1,28 +1,23 @@
 <h1 class="nhsuk-heading-l" id="<%= dom_id patient %>">
-    <%= patient.full_name %>
+  <%= patient.full_name %>
 </h1>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
+<%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
 
-    <div class="nhsuk-card" id="consent">
-      <div class="nhsuk-card__content">
-        <h2 class="nhsuk-card__heading nhsuk-heading-m">
-          Consent
-        </h2>
+<div class="nhsuk-card" id="consent">
+  <div class="nhsuk-card__content">
+    <h2 class="nhsuk-card__heading nhsuk-heading-m">
+      Consent
+    </h2>
 
-        <% if @consent_response.present? %>
-          <%= render "patient_triage_consent_response", consent_response: @consent_response %>
-        <% else %>
-          <p>
-            No response given
-          </p>
-        <% end %>
-      </div>
-    </div>
-
-    <%= render "patient_triage_card", session: @session, patient: @patient, triage: @triage %>
-
+    <% if @consent_response.present? %>
+      <%= render "patient_triage_consent_response", consent_response: @consent_response %>
+    <% else %>
+      <p>
+        No response given
+      </p>
+    <% end %>
   </div>
 </div>
+
+<%= render "patient_triage_card", session: @session, patient: @patient, triage: @triage %>

--- a/app/views/triage/_patient_triage.html.erb
+++ b/app/views/triage/_patient_triage.html.erb
@@ -22,7 +22,7 @@
       </div>
     </div>
 
-    <%= render "patient_triage_card", session: @session, triage: @triage %>
+    <%= render "patient_triage_card", session: @session, patient: @patient, triage: @triage %>
 
   </div>
 </div>

--- a/app/views/triage/_patient_triage_card.html.erb
+++ b/app/views/triage/_patient_triage_card.html.erb
@@ -8,6 +8,9 @@
                  url: session_patient_triage_path(
                     session, patient, triage
                  ) do |f| %>
+
+      <% content_for(:before_content) { f.govuk_error_summary } %>
+
       <%= f.govuk_text_area :notes, label: { text: 'Triage notes' }, rows: 5 %>
       <%= f.govuk_collection_radio_buttons :status,
                                            triage_form_status_options,

--- a/app/views/triage/_patient_triage_card.html.erb
+++ b/app/views/triage/_patient_triage_card.html.erb
@@ -5,6 +5,7 @@
     </h2>
 
     <%= form_for [session, triage], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= hidden_field(:triage, :patient_id) %>
       <%= f.govuk_text_area :notes, label: { text: 'Triage notes' }, rows: 5 %>
       <%= f.govuk_collection_radio_buttons :status,
                                            triage_form_status_options,

--- a/app/views/triage/_patient_triage_card.html.erb
+++ b/app/views/triage/_patient_triage_card.html.erb
@@ -1,0 +1,18 @@
+<div class="nhsuk-card">
+  <div class="nhsuk-card__content">
+    <h2 class="nhsuk-card__heading nhsuk-heading-m">
+      Triage
+    </h2>
+
+    <%= form_for [session, triage], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_text_area :notes, label: { text: 'Triage notes' }, rows: 5 %>
+      <%= f.govuk_collection_radio_buttons :status,
+                                           triage_form_status_options,
+                                           :first,
+                                           :second,
+                                           legend: { text: 'Triage status' } %>
+
+      <%= f.submit "Save triage", class: "nhsuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/triage/_patient_triage_card.html.erb
+++ b/app/views/triage/_patient_triage_card.html.erb
@@ -4,8 +4,10 @@
       Triage
     </h2>
 
-    <%= form_for [session, triage], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= hidden_field(:triage, :patient_id) %>
+    <%= form_for triage,
+                 url: session_patient_triage_path(
+                    session, patient, triage
+                 ) do |f| %>
       <%= f.govuk_text_area :notes, label: { text: 'Triage notes' }, rows: 5 %>
       <%= f.govuk_collection_radio_buttons :status,
                                            triage_form_status_options,

--- a/app/views/triage/show.html.erb
+++ b/app/views/triage/show.html.erb
@@ -11,7 +11,7 @@
 
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-               href: session_triage_index_path(@session),
+               href: triage_session_path(@session),
                name: "triage page"
              ) %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
   get "/csrf", to: "csrf#new"
 
   resources :sessions, only: %i[index show] do
-    resources :triage, only: %i[index show create]
+    get "triage", to: "triage#index", on: :member, param: :session_id
+    resources :patients do
+      resource :triage, only: %i[show create update]
+    end
 
     resources :patients,
               only: %i[index show],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "/csrf", to: "csrf#new"
 
   resources :sessions, only: %i[index show] do
-    resources :triage, only: %i[index show]
+    resources :triage, only: %i[index show create]
 
     resources :patients,
               only: %i[index show],

--- a/spec/requests/triage_spec.rb
+++ b/spec/requests/triage_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "/sessions/:session_id/triage", type: :request do
   let(:session) { create(:session, patients: [patient]) }
 
   describe "GET /sessions/:session_id/triage" do
-    before { get session_triage_index_url(session) }
+    before { get triage_session_url(session) }
 
     it "renders a successful response" do
       expect(response).to be_successful
@@ -23,7 +23,7 @@ RSpec.describe "/sessions/:session_id/triage", type: :request do
   end
 
   describe "GET /sessions/:session_id/triage/:patient_id" do
-    before { get session_triage_url(session, patient) }
+    before { get session_patient_triage_url(session, patient) }
 
     it "renders a successful response" do
       expect(response).to be_successful

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+let p = null;
+
 const patients = {
   "Aaron Pfeffer": {
     row: 1,
@@ -94,73 +96,89 @@ const patients = {
 };
 
 test("Performing triage", async ({ page }) => {
-  await page.goto("/reset");
+  p = page;
 
-  await page.goto("/sessions/1");
-  await page.getByRole("link", { name: "Triage" }).click();
-
-  await expect(page.locator("h1")).toContainText("Triage");
-
-  await then_i_should_see_the_correct_breadcrumbs(page);
-  await then_i_should_see_patients_with_their_triage_info(page);
+  await given_the_app_is_setup();
+  await when_i_go_to_the_triage_page_for_the_first_session();
+  await then_i_should_see_the_triage_index_page();
+  await then_i_should_see_the_correct_breadcrumbs();
+  await then_i_should_see_patients_with_their_triage_info();
 
   for (let name in patients) {
-    await page.getByRole("link", { name: name }).click();
-    await then_i_should_see_the_triage_page_for_the_patient(page, name);
-    await page.getByRole("link", { name: "Back to triage" }).click();
+    await when_i_click_on_the_patient(name);
+    await then_i_should_see_the_triage_page_for_the_patient(name);
+    await when_i_go_back_to_the_triage_index_page();
+    await then_i_should_see_the_triage_index_page();
   }
 });
 
-async function then_i_should_see_the_correct_breadcrumbs(page) {
-  await expect(
-    page.locator(".nhsuk-breadcrumb__item:last-of-type")
-  ).toContainText(
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function when_i_go_to_the_triage_page_for_the_first_session() {
+  await p.goto("/sessions/1");
+  await p.getByRole("link", { name: "Triage" }).click();
+}
+
+async function when_i_click_on_the_patient(name) {
+  await p.getByRole("link", { name: name }).click();
+}
+
+async function when_i_go_back_to_the_triage_index_page() {
+  await p.getByRole("link", { name: "Back to triage" }).click();
+}
+
+async function then_i_should_see_the_triage_index_page() {
+  await expect(p.locator("h1")).toContainText("Triage");
+}
+
+async function then_i_should_see_the_correct_breadcrumbs() {
+  await expect(p.locator(".nhsuk-breadcrumb__item:last-of-type")).toContainText(
     "HPV campaign at St Andrew's Benn CofE (Voluntary Aided) Primary School"
   );
 }
 
-async function then_i_should_see_patients_with_their_triage_info(page) {
+async function then_i_should_see_patients_with_their_triage_info() {
   for (let name in patients) {
     let patient = patients[name];
 
     await expect(
-      page.locator(`#patients tr:nth-child(${patient.row}) td:first-child`),
+      p.locator(`#patients tr:nth-child(${patient.row}) td:first-child`),
       `Name for patient row: ${patient.row} name: ${name}`
     ).toContainText(name);
 
     if (patient.note) {
       await expect(
-        page.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(2)`),
+        p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(2)`),
         `Note for patient row: ${patient.row} name: ${name}`
       ).toContainText(patient.note);
     } else {
       await expect(
-        page.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(2)`),
+        p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(2)`),
         `Empty note patient row: ${patient.row} name: ${name}`
       ).toBeEmpty();
     }
     await expect(
-      page.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(3)`),
+      p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(3)`),
       `Status text for patient row: ${patient.row} name: ${name}`
     ).toContainText(patient.status);
 
     await expect(
-      page.locator(
-        `#patients tr:nth-child(${patient.row}) td:nth-child(3) div`
-      ),
+      p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(3) div`),
       `Status colour for patient row: ${patient.row} name: ${name}`
     ).toHaveClass(new RegExp(patient.class));
 
     if (patient.icon) {
       await expect(
-        page.locator(
+        p.locator(
           `#patients tr:nth-child(${patient.row}) td:nth-child(3) div svg`
         ),
         `Status icon patient row: ${patient.row} name: ${name}`
       ).toHaveClass(new RegExp(patient.icon));
     } else {
       expect(
-        await page
+        await p
           .locator(
             `#patients tr:nth-child(${patient.row}) td:nth-child(3) div svg`
           )
@@ -171,13 +189,13 @@ async function then_i_should_see_patients_with_their_triage_info(page) {
   }
 }
 
-async function then_i_should_see_the_triage_page_for_the_patient(page, name) {
+async function then_i_should_see_the_triage_page_for_the_patient(name) {
   let patient = patients[name];
-  await expect(page.locator("h1")).toContainText(name);
+  await expect(p.locator("h1")).toContainText(name);
 
   let consentResponse = patient["consent_response"];
 
-  await expect(page.locator("#consent")).toContainText(consentResponse);
+  await expect(p.locator("#consent")).toContainText(consentResponse);
 
   if (consentResponse == "No response given") return;
 
@@ -189,18 +207,18 @@ async function then_i_should_see_the_triage_page_for_the_patient(page, name) {
   }
 
   if (parentRelationship) consentResponse += " " + parentRelationship;
-  await expect(page.locator("#consent")).toContainText(
+  await expect(p.locator("#consent")).toContainText(
     parentRelationship + " " + patient["parent_name"]
   );
 
   if (patient["type_of_consent"]) {
-    await expect(page.locator("#consent")).toContainText(
+    await expect(p.locator("#consent")).toContainText(
       "Type of consent " + patient["type_of_consent"]
     );
   }
 
   if (patient["reason_for_refusal"]) {
-    await expect(page.locator("#consent")).toContainText(
+    await expect(p.locator("#consent")).toContainText(
       "Reason for refusal " + patient["reason_for_refusal"]
     );
   }

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -113,10 +113,21 @@ test("Performing triage", async ({ page }) => {
 
   await when_i_click_on_the_patient("Aaron Pfeffer");
   await when_i_enter_the_note("Notes from nurse");
-  await when_i_click_on_the_option("Ready for session");
+  await when_i_click_on_the_option("Do not vaccinate");
   await when_i_click_on_the_submit_button();
   await then_i_should_see_a_triage_row_for_the_patient("Aaron Pfeffer", {
     note: "Notes from nurse",
+    status: "Do not vaccinate",
+    class: "nhsuk-tag--red",
+    icon: "nhsuk-icon__cross",
+  });
+
+  await when_i_click_on_the_patient("Aaron Pfeffer");
+  await when_i_clear_the_note();
+  await when_i_click_on_the_option("Ready for session");
+  await when_i_click_on_the_submit_button();
+  await then_i_should_see_a_triage_row_for_the_patient("Aaron Pfeffer", {
+    note: null,
     status: "Ready for session",
     class: "nhsuk-tag--green",
     icon: "nhsuk-icon__tick",
@@ -142,6 +153,10 @@ async function when_i_go_back_to_the_triage_index_page() {
 
 async function when_i_enter_the_note(note) {
   await p.getByLabel("Triage notes").type(note);
+}
+
+async function when_i_clear_the_note() {
+  await p.getByLabel("Triage notes").clear();
 }
 
 async function when_i_click_on_the_option(option) {

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -110,6 +110,10 @@ test("Performing triage", async ({ page }) => {
     await when_i_go_back_to_the_triage_index_page();
     await then_i_should_see_the_triage_index_page();
   }
+
+  await when_i_click_on_the_patient("Aaron Pfeffer");
+  await when_i_enter_the_note("Notes from nurse");
+  await when_i_click_on_the_option("Ready for session");
 });
 
 async function given_the_app_is_setup() {
@@ -127,6 +131,18 @@ async function when_i_click_on_the_patient(name) {
 
 async function when_i_go_back_to_the_triage_index_page() {
   await p.getByRole("link", { name: "Back to triage" }).click();
+}
+
+async function when_i_enter_the_note(note) {
+  await p.getByLabel("Triage notes").type(note);
+}
+
+async function when_i_click_on_the_option(option) {
+  await p.getByRole("radio", { name: option }).click();
+}
+
+async function when_i_click_on_the_submit_button() {
+  await p.getByRole("button", { name: "Save triage" }).click();
 }
 
 async function then_i_should_see_the_triage_index_page() {


### PR DESCRIPTION
Adds triage notes to patient triage page.

Note the change to the routes table (commit: [Nest triage route under sessions/patients](https://github.com/nhsuk/record-childrens-vaccinations/commit/ec6322c5d56efaaeaadd45eaf4369637fdc41571)). This change may be controversial and worth a discussion. If accepted it'll mean changes to the vaccinations routes (probably).

<img width="635" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/ad91aab1-2214-4726-8e2b-c23ed998868b">
