### PR TITLE
Fix the page alignment for the breadcrumbs, back-links and connection panel

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,8 +54,9 @@
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
 
-      <%= render "layouts/toggle_offline" %>
     </div>
+
+    <%= render "layouts/toggle_offline" %>
 
     <footer role="contentinfo">
       <div class="nhsuk-footer" id="nhsuk-footer">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,9 +47,9 @@
       </div>
     </header>
 
-    <div class="nhsuk-width-container">
-      <%= yield :before_main %>
+    <%= yield :before_main %>
 
+    <div class="nhsuk-width-container">
       <main class="nhsuk-main-wrapper" id="main-content" role="main">
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>


### PR DESCRIPTION
Before:

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/392d91d8-de8d-4c7a-abec-f13e5f4df72f)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/b99918fe-f898-44a2-bf04-5146390782c8)

After:

<img width="579" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/14d20312-45f7-4627-ac91-b85056168c6a">

<img width="475" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/e8859de5-6c52-4ff2-a4a9-64e97eb97bcb">
