### PR TITLE
Show empty state when a session has no vaccinations to record

### DIFF
--- a/app/assets/stylesheets/_empty-list.scss
+++ b/app/assets/stylesheets/_empty-list.scss
@@ -1,0 +1,5 @@
+.app-empty-list {
+  margin-top: nhsuk-spacing(6);
+  border: 2px solid $nhsuk-border-color;
+  min-height: 300px;
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,6 +9,7 @@ $govuk-assets-path: "/";
 
 $color_app-pale-blue: #ccdff1;
 
+@import "_empty-list.scss";
 @import "_offline.sass.scss";
 @import "_status-tag.scss";
 

--- a/app/views/layouts/_empty_list.html.erb
+++ b/app/views/layouts/_empty_list.html.erb
@@ -1,4 +1,4 @@
-<div style="margin-top: 32px; border: 2px solid #b1b4b6; min-height: 300px">
+<div class="app-empty-list">
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-heading-l">No results</h2>
     <p><%= message %></p>

--- a/app/views/layouts/_empty_list.html.erb
+++ b/app/views/layouts/_empty_list.html.erb
@@ -1,0 +1,6 @@
+<div style="margin-top: 32px; border: 2px solid #b1b4b6; min-height: 300px">
+  <div class="nhsuk-card__content">
+    <h2 class="nhsuk-heading-l">No results</h2>
+    <p><%= message %></p>
+  </div>
+</div>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -1,36 +1,44 @@
-<% if flash[:success].present? %>
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success][:title]) %>
-      <p><%= flash[:success][:body] %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if flash[:success].present? %>
+      <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
+        <% if flash[:success].is_a?(Hash) %>
+          <% nb.with_heading(text: flash[:success][:title]) %>
+          <p><%= flash[:success][:body] %></p>
+        <% else %>
+          <% nb.with_heading(text: flash[:success]) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% content_for :before_main do %>
+      <%= render AppBreadcrumbComponent.new(items: [
+        { text: 'Home', href: dashboard_path },
+        { text: 'School sessions', href: sessions_path },
+        { text: @session.name, href: session_path(@session) },
+      ]) %>
+    <% end %>
+
+    <h1>Record vaccinations</h1>
+
+    <% if @patient_outcomes.any? %>
+      <table class="nhsuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">Name</th>
+            <th class="govuk-table__header">Date of birth</th>
+            <th class="govuk-table__header">Consent</th>
+            <th class="govuk-table__header">Outcome</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @patient_outcomes.each do |patient, outcome| %>
+            <%= render "patient_row", patient:, outcome: %>
+          <% end %>
+        </tbody>
+      </table>
     <% else %>
-      <% nb.with_heading(text: flash[:success]) %>
+      <%= render "layouts/empty_list", message: "We couldn’t find any children in this session." %>
     <% end %>
-  <% end %>
-<% end %>
-
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'School sessions', href: sessions_path },
-    { text: @session.name, href: session_path(@session) },
-  ]) %>
-<% end %>
-
-<h1>Record vaccinations</h1>
-
-<table class="nhsuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">Name</th>
-      <th class="govuk-table__header">Date of birth</th>
-      <th class="govuk-table__header">Consent</th>
-      <th class="govuk-table__header">Outcome</th>
-    </tr>
-  </thead>
-    <tbody class="govuk-table__body">
-    <% @patient_outcomes.each do |patient, outcome| %>
-      <%= render "patient_row", patient:, outcome: %>
-    <% end %>
-  </tbody>
-</table>
+  </div>
+</div>


### PR DESCRIPTION
## What's changed

1. Made the "record vaccinations" index page two-thirds width, to bring closer to the designs
2. Introduced an empty state when there are no vaccinations to record. This will come in handy when tabs are introduced.

<img width="792" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/013eea93-f236-4f94-9d0e-a49b79835b85">

## Questions for reviewers

1. There's some inline CSS – should I extract it into the CSS files? If so, what could I name the class?
2. Does the proposed microcopy for the empty state make sense?