### PR TITLE
Record vaccinations: display actions and outcomes

### DIFF
--- a/app/assets/stylesheets/_action-tag.scss
+++ b/app/assets/stylesheets/_action-tag.scss
@@ -1,0 +1,11 @@
+.app-action-tag {
+  // border-width: 0 0 0 3px;
+  font-weight: bold;
+
+  &.nhsuk-tag--white {
+    background: none;
+    font-weight: normal;
+    border-width: 1px;
+    border-style: dashed;
+  }
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,6 +9,7 @@ $govuk-assets-path: "/";
 
 $color_app-pale-blue: #ccdff1;
 
+@import "_action-tag.scss";
 @import "_empty-list.scss";
 @import "_offline.sass.scss";
 @import "_status-tag.scss";

--- a/app/components/app_action_tag_component.html.erb
+++ b/app/components/app_action_tag_component.html.erb
@@ -1,0 +1,5 @@
+<div class="app-action-tag nhsuk-tag nhsuk-tag--<%= colour %>" style="width: 100%">
+  <span class="nhsuk-u-font-size-16">
+    <%= status %>
+  </span>
+</div>

--- a/app/components/app_action_tag_component.rb
+++ b/app/components/app_action_tag_component.rb
@@ -1,0 +1,10 @@
+class AppActionTagComponent < ViewComponent::Base
+  attr_reader :status, :colour
+
+  def initialize(status:, colour:)
+    super
+
+    @status = status
+    @colour = colour
+  end
+end

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -14,6 +14,31 @@ module VaccinationsHelper
     end
   end
 
+  def vaccination_action_colour(action_or_outcome)
+    case action_or_outcome
+    when :get_consent
+      :yellow
+    when :check_refusal
+      :orange
+    when :vaccinated
+      :green
+    when :not_vaccinated
+      :orange
+    when :vaccinate
+      :purple
+    when :triage
+      :blue
+    when :follow_up
+      :"aqua-green"
+    when :do_not_vaccinate
+      :red
+    when :unknown
+      :white
+    else
+      :white
+    end
+  end
+
   def vaccination_status_icon(status)
     case status
     when :no_consent, :could_not_vaccinate

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -20,6 +20,7 @@ class Campaign < ApplicationRecord
   belongs_to :vaccine
   has_many :sessions, dependent: :destroy
   has_many :triage, dependent: :destroy
+  has_many :consent_responses, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/views/vaccinations/_patient_row.html.erb
+++ b/app/views/vaccinations/_patient_row.html.erb
@@ -6,12 +6,8 @@
   <td class="govuk-table__cell" style="width: 150px">
     <%= patient.dob.strftime("%d %b %Y") %>
   </td>
-  <td class="govuk-table__cell">
-    <%= patient.consent %>
-  </td>
-  <td class="govuk-table__cell" data-testid="child-status">
-    <%= render(AppStatusTagComponent.new(status: PatientSession.human_enum_name("outcome", outcome),
-                                         colour: vaccination_status_colour(outcome),
-                                         icon: vaccination_status_icon(outcome))) %>
+  <td class="govuk-table__cell" data-testid="child-action">
+    <% label = PatientSession.human_enum_name("actions_or_outcome", action_or_outcome[:action] || action_or_outcome[:outcome]) %>
+    <%= render(AppActionTagComponent.new(status: label, colour: vaccination_action_colour(action_or_outcome[:action] || action_or_outcome[:outcome]))) %>
   </td>
 </tr>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -19,19 +19,18 @@
 
 <h1>Record vaccinations</h1>
 
-<% if @patient_outcomes.any? %>
+<% if @patient_details.any? %>
   <table class="nhsuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Name</th>
         <th class="govuk-table__header">Date of birth</th>
-        <th class="govuk-table__header">Consent</th>
-        <th class="govuk-table__header">Outcome</th>
+        <th class="govuk-table__header" style="width: 200px">Action</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @patient_outcomes.each do |patient, outcome| %>
-        <%= render "patient_row", patient:, outcome: %>
+      <% @patient_details.each do |patient, action_or_outcome| %>
+        <%= render "patient_row", patient:, action_or_outcome: %>
       <% end %>
     </tbody>
   </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,16 @@ en:
           no_outcome: No outcome yet
           no_consent: No consent
           vaccinated: Vaccinated
+        actions_or_outcomes:
+          get_consent: Get consent
+          check_refusal: Check refusal
+          vaccinated: Vaccinated
+          not_vaccinated: Could not vaccinate
+          vaccinate: Vaccinate
+          triage: Triage
+          follow_up: "Triage: follow up"
+          do_not_vaccinate: Do not vaccinate
+          unknown: Unknown
       triage:
         statuses:
           to_do: To do

--- a/tests/vaccinations.spec.ts
+++ b/tests/vaccinations.spec.ts
@@ -8,7 +8,7 @@ test("Records vaccinations", async ({ page }) => {
   await given_the_app_is_setup();
 
   await when_i_go_to_the_vaccinations_page();
-  await then_i_should_see_no_outcome_yet();
+  await then_i_should_see_the_action_to_vaccinate();
 
   await when_i_click_on_the_first_patient();
   await then_i_should_see_the_vaccinations_page();
@@ -18,6 +18,7 @@ test("Records vaccinations", async ({ page }) => {
 
   await when_i_press_confirm();
   await then_i_should_see_a_success_message();
+  await and_i_should_see_the_outcome_as_vaccinated();
 
   await when_i_click_on_the_patient("Aaron Pfeffer");
   await then_i_should_see_the_medical_history_section();
@@ -34,10 +35,8 @@ async function when_i_go_to_the_vaccinations_page() {
   await p.goto("/sessions/1/vaccinations");
 }
 
-async function then_i_should_see_no_outcome_yet() {
-  await expect(p.getByTestId("child-status").nth(0)).toContainText(
-    "No outcome yet"
-  );
+async function then_i_should_see_the_action_to_vaccinate() {
+  await expect(p.getByTestId("child-action").nth(0)).toContainText("Vaccinate");
 }
 
 async function when_i_click_on_the_first_patient() {
@@ -58,6 +57,12 @@ async function when_i_record_a_vaccination() {
 
 async function then_i_should_see_a_success_message() {
   await expect(p.getByRole("alert")).toContainText("Success");
+}
+
+async function and_i_should_see_the_outcome_as_vaccinated() {
+  await expect(p.getByTestId("child-action").nth(0)).toContainText(
+    "Vaccinated"
+  );
 }
 
 async function then_i_should_see_the_check_answers_page() {


### PR DESCRIPTION
## What is this change?

Update the designs of the record vaccinations index page to show actions and outcomes.

## Before

<img width="811" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/9a60d8cc-57e5-41c5-987b-b378dc30b53f">

## After

<img width="832" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/52f8a6c6-f7a4-45c5-854a-866fc70e29c9">
