### PR TITLE
Display triage info in vaccinations#show page

### DIFF
--- a/app/views/triage/_patient_triage.html.erb
+++ b/app/views/triage/_patient_triage.html.erb
@@ -2,8 +2,6 @@
   <%= patient.full_name %>
 </h1>
 
-<%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
-
 <div class="nhsuk-card" id="consent">
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
@@ -19,6 +17,8 @@
     <% end %>
   </div>
 </div>
+
+<%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
 
 <% if @consent_response&.health_questions.present? %>
 <div class="nhsuk-card" id="health-questions">

--- a/app/views/triage/_patient_triage_consent_response.html.erb
+++ b/app/views/triage/_patient_triage_consent_response.html.erb
@@ -4,7 +4,7 @@
       <%= consent_response.consent_given? ? "Given by" : "Refused by" %>
     </dt>
     <dd class="nhsuk-summary-list__value">
-      <%= parent_relationship(consent_response) %>
+      <%= parent_relationship(consent_response).humanize %>
     </dd>
   </div>
 

--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -3,8 +3,6 @@
 </h1>
 
 <div data-controller="child-vaccination">
-  <%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
-
   <div class="nhsuk-card" id="consent">
     <div class="nhsuk-card__content">
       <h2 class="nhsuk-card__heading nhsuk-heading-m">
@@ -20,6 +18,8 @@
       <% end %>
     </div>
   </div>
+
+  <%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
 
   <% if @consent_response&.health_questions.present? %>
     <div class="nhsuk-card" id="consent">

--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -5,6 +5,22 @@
 <div data-controller="child-vaccination">
   <%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
 
+  <div class="nhsuk-card" id="consent">
+    <div class="nhsuk-card__content">
+      <h2 class="nhsuk-card__heading nhsuk-heading-m">
+        Consent
+      </h2>
+
+      <% if @consent_response.present? %>
+        <%= render "triage/patient_triage_consent_response", consent_response: @consent_response %>
+      <% else %>
+        <p>
+          No response given
+        </p>
+      <% end %>
+    </div>
+  </div>
+
   <% if @consent_response&.health_questions.present? %>
     <div class="nhsuk-card" id="consent">
       <div class="nhsuk-card__content">


### PR DESCRIPTION
One issue with this approach is that we're using a `triage/` partial in a vaccinations view. Ideally, we'd want to componentise this. In the interest of speed, let's kick that to later.

Humanise consentee in consent card so that `grandmother` becomes `Grandmother`.

Display consent above patient card info as per the prototype (both triage and vaccination show pages).

### Before

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/c63653dc-a1a2-473f-8c11-3f035eedeb89)

### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/14ec7c32-31b2-48ba-a87f-ccdb85ca5799)
