### PR TITLE
Add notes to health questions when response is yes

### DIFF
--- a/app/components/app_health_questions_component.html.erb
+++ b/app/components/app_health_questions_component.html.erb
@@ -2,5 +2,9 @@
   <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-0">
     <%= health_question["question"] %>
   </h3>
-  <p><%= health_question["response"].humanize %></p>
+  <% if health_question["response"].downcase == "yes" %>
+    <p><%= health_question["response"].humanize %> &ndash; <%= health_question["notes"] %></p>
+  <% else %>
+    <p><%= health_question["response"].humanize %></p>
+  <% end %>
 <% end %>

--- a/db/sample_data/example-campaign.json
+++ b/db/sample_data/example-campaign.json
@@ -394,7 +394,31 @@
         "parentRelationship": "mother",
         "parentEmail": "Erika54@hotmail.com",
         "gpResponse": "no",
-        "route": "website"
+        "route": "website",
+        "healthQuestionResponses": [
+          {
+            "question": "Does the child have a disease or treatment that severely affects their immune system?",
+            "response": "yes",
+            "notes": "Archie has had a really bad cold for the last 2 weeks"
+          },
+          {
+            "question": "Is anyone in your household having treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+            "response": "no"
+          },
+          {
+            "question": "Is there anything else we should know?",
+            "response": "yes",
+            "notes": "He is also very nervous around needles"
+          }
+        ]
       }
     },
     {

--- a/db/sample_data/example-test-campaign.json
+++ b/db/sample_data/example-test-campaign.json
@@ -114,23 +114,25 @@
         "healthQuestionResponses": [
           {
             "question": "Does the child have a disease or treatment that severely affects their immune system?",
-            "response": "yes"
+            "response": "yes",
+            "notes": "Has a pretty bad cold"
           },
           {
             "question": "Is anyone in your household having treatment that severely affects their immune system?",
-            "response": "yes"
+            "response": "no"
           },
           {
             "question": "Has your child been diagnosed with asthma?",
-            "response": "yes"
+            "response": "no"
           },
           {
             "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
-            "response": "yes"
+            "response": "no"
           },
           {
             "question": "Is there anything else we should know?",
-            "response": "deathly afraid of nasal sprays"
+            "response": "yes",
+            "notes": "Deathly afraid of nasal sprays"
           }
         ]
       }

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -1,6 +1,31 @@
 require "rails_helper"
 
 RSpec.describe AppHealthQuestionsComponent, type: :component do
+  health_questions = [
+    {
+      question:
+        "Does the child have a disease or treatment that severely affects their immune system?",
+      response: "no"
+    },
+    {
+      question:
+        "Is anyone in your household having treatment that severely affects their immune system?",
+      response: "no"
+    },
+    { question: "Has your child been diagnosed with asthma?", response: "no" },
+    {
+      question:
+        "Has your child been admitted to intensive care because of a severe egg allergy?",
+      response: "no"
+    },
+    {
+      question: "Is there anything else we should know?",
+      response: "yes",
+      notes:
+        "Please be aware my daughter likes to play with needles and will try to grab them"
+    }
+  ].freeze
+
   before { render_inline(component) }
 
   subject { page }
@@ -8,31 +33,16 @@ RSpec.describe AppHealthQuestionsComponent, type: :component do
   let(:patient) { FactoryBot.create(:patient) }
   let(:session) { FactoryBot.create(:session) }
   let(:consent_response) do
-    create :consent_response, patient:, campaign: session.campaign
+    create :consent_response,
+           patient:,
+           campaign: session.campaign,
+           health_questions:
   end
 
   let(:component) { described_class.new(consent_response:) }
 
   # Copy pasted from the consent_responses factory
-  [
-    {
-      question:
-        "Does the child have a disease or treatment that severely affects their immune system?",
-      response: "No"
-    },
-    {
-      question:
-        "Is anyone in your household having treatment that severely affects their immune system?",
-      response: "No"
-    },
-    { question: "Has your child been diagnosed with asthma?", response: "No" },
-    {
-      question:
-        "Has your child been admitted to intensive care because of a severe egg allergy?",
-      response: "No"
-    },
-    { question: "Is there anything else we should know?", response: "No" }
-  ].each_with_index do |health_question, i|
+  health_questions.each_with_index do |health_question, i|
     it "should have the health question #{i}" do
       expect(page.find_css("h3:nth(#{i + 1})").text).to(
         match(/^\s*#{Regexp.escape(health_question[:question])}\s*$/s)
@@ -40,9 +50,13 @@ RSpec.describe AppHealthQuestionsComponent, type: :component do
     end
 
     it "should have the answer to health question #{i}" do
-      expect(page.find_css("p:nth(#{i + 1})").text).to(
-        match(/^\s*#{health_question[:response]}\s*$/)
-      )
+      if health_question[:response].downcase == "yes"
+        expect(page.find_css("p:nth(#{i + 1})").text).to(
+          match(/^\s*Yes – #{health_question[:notes]}\s*$/)
+        )
+      else
+        expect(page.find_css("p:nth(#{i + 1})").text).to(match(/^\s*No\s*$/))
+      end
     end
   end
 end

--- a/spec/factories/consent_responses.rb
+++ b/spec/factories/consent_responses.rb
@@ -57,23 +57,23 @@ FactoryBot.define do
         {
           question:
             "Does the child have a disease or treatment that severely affects their immune system?",
-          response: "No"
+          response: "no"
         },
         {
           question:
             "Is anyone in your household having treatment that severely affects their immune system?",
-          response: "No"
+          response: "no"
         },
         {
           question: "Has your child been diagnosed with asthma?",
-          response: "No"
+          response: "no"
         },
         {
           question:
             "Has your child been admitted to intensive care because of a severe egg allergy?",
-          response: "No"
+          response: "no"
         },
-        { question: "Is there anything else we should know?", response: "No" }
+        { question: "Is there anything else we should know?", response: "no" }
       ]
     end
 

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -276,10 +276,18 @@ async function then_i_should_see_health_question_responses_if_present(name) {
 
     for (const example_question of consent["healthQuestionResponses"]) {
       await expect(
-        p.getByRole("heading", {
-          name: example_question["question"],
-        })
-      ).toContainText(example_question["question"]);
+        p.locator("h3:text('" + example_question.question + "')")
+      ).toContainText(example_question.question);
+
+      if (example_question["response"].toLowerCase() == "yes") {
+        await expect(
+          p.locator("h3:text('" + example_question.question + "') + p")
+        ).toContainText("Yes – " + example_question.notes);
+      } else {
+        await expect(
+          p.locator("h3:text('" + example_question.question + "') + p")
+        ).toContainText("No");
+      }
     }
   } else {
     expect(await p.textContent("body")).not.toContain("Health questions");


### PR DESCRIPTION
When health question response is "Yes", display it with the additional notes: "Yes – Notes go here"

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/16610bd8-8c95-46c2-9b25-f40d982c33a2)
