### PR TITLE
Standardise formatting of dates and times, make more Rails-idiomatic

### DIFF
--- a/app/components/app_patient_card_component.html.erb
+++ b/app/components/app_patient_card_component.html.erb
@@ -19,7 +19,7 @@
           Date of birth
         </dt>
         <dd class="nhsuk-summary-list__value" data-child-vaccination-target="dob">
-          <%= @patient.dob&.strftime("%d %B %Y") %> (<%= aged %>)
+          <%= @patient.dob&.to_fs(:nhsuk_date) %> (<%= aged %>)
         </dd>
       </div>
 

--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <%= session.date.strftime("%d %b %Y") %>
+    <%= session.date.to_fs(:nhsuk_date_short_month) %>
   </td>
   <td class="govuk-table__cell">
     <%= session.date.strftime("%l%P") %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -8,7 +8,7 @@
 <h1 class="nhsuk-heading-l">
   <%= @session.name %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    <%= @session.date.strftime('%e %B %Y at %l%P') %>
+    <%= @session.date.to_fs(:long_ordinal_uk) %>
   </span>
 </h1>
 

--- a/app/views/triage/_patient_row.html.erb
+++ b/app/views/triage/_patient_row.html.erb
@@ -3,7 +3,7 @@
     <%= link_to patient.full_name, session_patient_triage_path(@session, patient), "data-testid": "child-link" %>
   </td>
   <td class="govuk-table__cell" style="width: 150px">
-    <%= patient.dob.strftime("%d %b %Y") %>
+    <%= patient.dob.to_fs(:nhsuk_date_short_month) %>
   </td>
   <td class="govuk-table__cell" data-testid="child-action">
     <% label = PatientSession.human_enum_name("actions_or_outcome", action_or_outcome[:action] || action_or_outcome[:outcome]) %>

--- a/app/views/triage/_patient_triage_consent_response.html.erb
+++ b/app/views/triage/_patient_triage_consent_response.html.erb
@@ -31,7 +31,7 @@
       Date
     </dt>
     <dd class="nhsuk-summary-list__value">
-      <%= consent_response.created_at.to_fs(:date_uk) %>
+      <%= consent_response.created_at.to_fs(:nhsuk_date) %>
     </dd>
   </div>
 

--- a/app/views/vaccinations/_patient_row.html.erb
+++ b/app/views/vaccinations/_patient_row.html.erb
@@ -4,7 +4,7 @@
       "data-testid": "child-link" %>
   </td>
   <td class="govuk-table__cell" style="width: 150px">
-    <%= patient.dob.strftime("%d %b %Y") %>
+    <%= patient.dob.to_fs(:nhsuk_date_short_month) %>
   </td>
   <td class="govuk-table__cell" data-testid="child-action">
     <% label = PatientSession.human_enum_name("actions_or_outcome", action_or_outcome[:action] || action_or_outcome[:outcome]) %>

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -42,7 +42,7 @@
 
       summary_list.with_row do |row|
         row.with_key { 'Date' }
-        row.with_value { "Today (#{Time.zone.now.strftime("%d %B %Y")})" }
+        row.with_value { "Today (#{Time.zone.now.to_fs(:nhsuk_date)})" }
       end
 
       summary_list.with_row do |row|

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
-Time::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
+Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y"
+Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y"

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
-Time::DATE_FORMATS[:long_ordinal_uk] = "%d %B %Y at %l:%M%P"
-Time::DATE_FORMATS[:date_uk] = "%d %B %Y"
+Time::DATE_FORMATS[:long_ordinal_uk] = "-%d %B %Y at %l:%M%P"
+Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y"
+Time::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y"

--- a/spec/components/app_patient_card_component_spec.rb
+++ b/spec/components/app_patient_card_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AppPatientCardComponent, type: :component do
   end
 
   it "should render the patient's date of birth" do
-    expected_dob = "#{patient.dob.strftime("%d %B %Y")} (aged #{patient.age})"
+    expected_dob = "#{patient.dob.to_fs(:nhsuk_date)} (aged #{patient.age})"
     expect(page).to have_css(
       '.nhsuk-summary-list__value[data-child-vaccination-target="dob"]',
       text: expected_dob


### PR DESCRIPTION
The NHS Digital Service Manual [says the following about dates](https://service-manual.nhs.uk/content/numbers-measurements-dates-time#dates):

> We use this format: 6 August 2018.