### PR TITLE
Move faker out of test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "awesome_print"
 gem "bootsnap", require: false
 gem "config"
 gem "cssbundling-rails"
+gem "faker", github: "misaka/faker", branch: "add_alternative_name"
 gem "fhir_client"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
@@ -50,7 +51,6 @@ end
 group :test do
   gem "capybara"
   gem "cuprite"
-  gem "faker", github: "misaka/faker", branch: "add_alternative_name"
   gem "rspec"
   gem "webmock"
 end


### PR DESCRIPTION
Since we use it for rake tasks, Heroku expects it to be available in the production env.

This fixes deployments. The review app on this branch should deploy successfully.