### PR TITLE
Minor UI fixes/tweaks about consent responder

### DIFF
--- a/app/helpers/triage_helper.rb
+++ b/app/helpers/triage_helper.rb
@@ -19,17 +19,6 @@ module TriageHelper
     ]
   end
 
-  def parent_relationship(consent_response)
-    if consent_response.parent_relationship == "other"
-      consent_response.parent_relationship_other
-    else
-      ConsentResponse.human_enum_name(
-        "parent_relationship",
-        consent_response.parent_relationship
-      )
-    end
-  end
-
   def triage_form_status_options
     Triage.statuses.keys.map do |status|
       [status, Triage.human_enum_name(:status, status)]

--- a/app/models/consent_response.rb
+++ b/app/models/consent_response.rb
@@ -63,6 +63,14 @@ class ConsentResponse < ApplicationRecord
       (parent_relationship_other? || health_questions_require_follow_up?)
   end
 
+  def who_responded
+    if parent_relationship == "other"
+      parent_relationship_other
+    else
+      self.class.human_enum_name("parent_relationship", parent_relationship)
+    end
+  end
+
   private
 
   def health_questions_require_follow_up?

--- a/app/views/triage/_patient_triage_consent_response.html.erb
+++ b/app/views/triage/_patient_triage_consent_response.html.erb
@@ -4,13 +4,13 @@
       <%= consent_response.consent_given? ? "Given by" : "Refused by" %>
     </dt>
     <dd class="nhsuk-summary-list__value">
-      <%= parent_relationship(consent_response).humanize %>
+      <%= consent_response.who_responded.capitalize %>
     </dd>
   </div>
 
   <div class="nhsuk-summary-list__row">
     <dt class="nhsuk-summary-list__key">
-      <%= parent_relationship(consent_response) %>
+      <%= consent_response.who_responded.capitalize %>
     </dt>
     <dd class="nhsuk-summary-list__value">
       <%= consent_response.parent_name %>

--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -5,7 +5,7 @@
 <% if @vaccination_record&.administered? %>
   <%= render AppBannerComponent.new(
                 title: "Vaccinated",
-                explanation: @consent_response.present? ? "Their #{@consent_response.parent_relationship} gave consent" : "",
+                explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
                 colour: "green"
               ) %>
 

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -23,7 +23,7 @@ const patients = {
     consent_response: "Given by",
     parent_name: "Garret Lakin",
     parent_email: "Garret57@hotmail.com",
-    parent_relationship: "grandmother",
+    parent_relationship: "Grandmother",
     type_of_consent: "Website",
   },
   "Aliza Kshlerin": {


### PR DESCRIPTION
## What does this PR change?

* it fixes a couple of UI glitches
  * "their other gave consent"
  * small g on grandmother
* move a helper method onto the model, closer to the data

## Before

<img width="714" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/e661adaa-3f82-4f39-8697-8e0028f4e197">

## After

<img width="713" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/265d683a-a8c9-4f79-a898-922d8c0d0195">

