### PR TITLE
Record Vaccs: orange check refusal banner

### DIFF
--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -13,6 +13,13 @@
 
 <div data-controller="child-vaccination">
   <% if @consent_response.present? %>
+    <% if @consent_response.consent_refused? %>
+      <%= render AppBannerComponent.new(
+              title: "Their #{@consent_response.who_responded.downcase} has refused to give consent",
+              colour: "orange"
+            ) %>
+    <% end %>
+
     <div class="nhsuk-card" id="consent">
       <div class="nhsuk-card__content">
         <h2 class="nhsuk-card__heading nhsuk-heading-m">


### PR DESCRIPTION
Relies on #298 and #299

<img width="695" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/632669bc-2d80-47dd-8164-fc851a02c4b8">
