### PR TITLE
Record vaccs: orange 'could not vaccinate' banner on child page

### DIFF
--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -8,7 +8,13 @@
                 explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
                 colour: "green"
               ) %>
-
+<% elsif @vaccination_record&.administered == false %>
+  <%= render AppBannerComponent.new(
+                title: "Could not vaccinate",
+                # TODO: add reason for refusal once that is collected
+                explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
+                colour: "orange"
+              ) %>
 <% end %>
 
 <div data-controller="child-vaccination">


### PR DESCRIPTION
This implementation deviates from the prototype designs because the app currently doesn't record the reason for vaccination not occurring.

<img width="708" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/a3fb021a-8ba8-496f-b93f-9b14cb340eff">
