### PR TITLE
Add medical history component

### DIFF
--- a/app/components/app_patient_medical_history_card_component.html.erb
+++ b/app/components/app_patient_medical_history_card_component.html.erb
@@ -1,0 +1,48 @@
+<div class="nhsuk-card">
+  <div class="nhsuk-card__content">
+    <h2 class="nhsuk-card__heading nhsuk-heading-m">
+      Medical history
+    </h2>
+
+    <% if @consent_response.triage_needed? %>
+      <% if triage_present? %>
+        <p>Triage needed</p>
+
+        <ul class="nhsuk-list nhsuk-list--bullet">
+          <% reasons_triage_needed.each do |reason| %>
+            <li><%= reason %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <% if @triage.notes.present? %>
+          <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Triage notes</h2>
+          <p><%= @triage.notes %></p>
+        <% else %>
+          <p>Triage complete - no notes</p>
+        <% end %>
+      <% end %>
+
+      <% if @consent_response.health_questions.present? %>
+        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Medical history answers</h2>
+      <% end %>
+
+    <% else %>
+      <p>No triage needed</p>
+    <% end %>
+
+    <% if @consent_response.health_questions.present? %>
+      <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
+        <summary class="nhsuk-details__summary">
+          <span class="nhsuk-details__summary-text">
+            Show answers
+          </span>
+        </summary>
+
+        <div class="nhsuk-details__text">
+          <%= render AppHealthQuestionsComponent.new(consent_response: @consent_response) %>
+        </div>
+      </details>
+
+    <% end %>
+  </div>
+</div>

--- a/app/components/app_patient_medical_history_card_component.rb
+++ b/app/components/app_patient_medical_history_card_component.rb
@@ -1,0 +1,24 @@
+class AppPatientMedicalHistoryCardComponent < ViewComponent::Base
+  def initialize(patient:, consent_response:, triage:)
+    super
+
+    @patient = patient
+    @consent_response = consent_response
+    @triage = triage
+  end
+
+  def triage_present?
+    @triage.blank? || !@triage.persisted?
+  end
+
+  def reasons_triage_needed
+    reasons = []
+    if @consent_response.parent_relationship_other?
+      reasons << "Check parental responsibility"
+    end
+    if @consent_response.health_questions_require_follow_up?
+      reasons << "Notes need triage"
+    end
+    reasons
+  end
+end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -5,6 +5,7 @@ class VaccinationsController < ApplicationController
   before_action :set_draft_vaccination_record, only: %i[show confirm record]
   before_action :set_vaccination_record, only: %i[show confirm record]
   before_action :set_consent_response, only: :show
+  before_action :set_triage, only: :show
 
   layout "two_thirds"
 
@@ -131,5 +132,11 @@ class VaccinationsController < ApplicationController
   def set_consent_response
     @consent_response =
       @patient.consent_response_for_campaign(@session.campaign)
+  end
+
+  def set_triage
+    @triage =
+      @patient.triage_for_campaign(@session.campaign) ||
+        Triage.new(campaign: @session.campaign, patient: @patient)
   end
 end

--- a/app/models/consent_response.rb
+++ b/app/models/consent_response.rb
@@ -71,8 +71,6 @@ class ConsentResponse < ApplicationRecord
     end
   end
 
-  private
-
   def health_questions_require_follow_up?
     health_questions&.any? { |question| question["response"].downcase == "yes" }
   end

--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -44,28 +44,13 @@
 
   <%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
 
-  <% if @consent_response&.health_questions.present? %>
-    <div class="nhsuk-card" id="consent">
-      <div class="nhsuk-card__content">
-        <h2 class="nhsuk-card__heading nhsuk-heading-m">
-          Medical history
-        </h2>
-
-        <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
-          <summary class="nhsuk-details__summary">
-            <span class="nhsuk-details__summary-text">
-              Show answers
-            </span>
-          </summary>
-
-          <div class="nhsuk-details__text">
-            <%= render AppHealthQuestionsComponent.new(consent_response: @consent_response) %>
-          </div>
-        </details>
-      </div>
-    </div>
+  <% if @consent_response&.consent_given? %>
+    <%= render AppPatientMedicalHistoryCardComponent.new(
+      patient: @patient,
+      consent_response: @consent_response,
+      triage: @triage
+    ) %>
   <% end %>
-
 
   <div class="nhsuk-card">
     <div class="nhsuk-card__content">

--- a/db/sample_data/example-campaign.json
+++ b/db/sample_data/example-campaign.json
@@ -82,7 +82,29 @@
         "parentRelationship": "father",
         "parentEmail": "Betty_Pfeffer62@yahoo.com",
         "gpResponse": "no",
-        "route": "paper"
+        "route": "paper",
+        "healthQuestionResponses": [
+          {
+            "question": "Does the child have a disease or treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Is anyone in your household having treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+            "response": "no"
+          },
+          {
+            "question": "Is there anything else we should know?",
+            "response": "no"
+          }
+        ]
       }
     },
     {
@@ -108,7 +130,8 @@
         "classes": "nhsuk-tag--grey"
       },
       "triage": {
-        "status": "ready_to_vaccinate"
+        "status": "ready_to_vaccinate",
+        "notes": "Spoke with parent, it is safe to vaccinate"
       },
       "consent": {
         "consent": "given",

--- a/db/sample_data/example-test-campaign.json
+++ b/db/sample_data/example-test-campaign.json
@@ -97,7 +97,8 @@
       "dob": "2018-04-15",
       "nhsNumber": "7955258493",
       "triage": {
-        "status": "ready_to_vaccinate"
+        "status": "ready_to_vaccinate",
+        "notes": "Spoke with parent, it is safe to vaccinate"
       },
       "consent": {
         "consent": "given",
@@ -143,10 +144,6 @@
       "lastName": "Kshlerin",
       "dob": "2011-03-27",
       "nhsNumber": "5996235637",
-      "triage": {
-        "status": "ready_to_vaccinate",
-        "notes": "Spoke with parent, it is safe to vaccinate"
-      },
       "consent": {
         "consent": "given",
         "dob": "2011-03-27",

--- a/spec/components/app_patient_medical_history_card_component_spec.rb
+++ b/spec/components/app_patient_medical_history_card_component_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
+  before { render_inline(component) }
+
+  subject { page }
+
+  let(:health_questions) do
+    [{ question: "Is there anything else we should know?", response: "no" }]
+  end
+  let(:patient) { FactoryBot.create(:patient) }
+  let(:session) { FactoryBot.create(:session) }
+  let(:consent_response) do
+    create :consent_response,
+           patient:,
+           campaign: session.campaign,
+           health_questions:
+  end
+  let(:triage_notes) { nil }
+  let(:triage) { Triage.new(campaign: session.campaign, patient:) }
+  let(:component) { described_class.new(patient:, consent_response:, triage:) }
+
+  it "renders correctly" do
+    expect(page).to have_css(".nhsuk-card")
+    expect(page).to have_css(".nhsuk-card__content")
+  end
+
+  context "consent given and no triage needed" do
+    it "renders correctly" do
+      expect(page).to have_css(".nhsuk-card__heading", text: "Medical history")
+      expect(page).to have_css("p:first", text: "No triage needed")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "parent is other and triage is not done" do
+    let(:consent_response) do
+      create :consent_response,
+             :from_granddad,
+             patient:,
+             campaign: session.campaign
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("p:first", text: "Triage needed")
+      expect(page).to have_css("li", text: "Check parental responsibility")
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "parent is other and triage is done with notes" do
+    let(:consent_response) do
+      create :consent_response,
+             :from_granddad,
+             patient:,
+             campaign: session.campaign
+    end
+    let(:triage_notes) { "These are triage notes" }
+    let(:triage) do
+      create :triage, patient:, campaign: session.campaign, notes: triage_notes
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("h2:nth(2)", text: "Triage notes")
+      expect(page).to have_css("p:first", text: triage_notes)
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "parent is other and triage is done without notes" do
+    let(:consent_response) do
+      create :consent_response,
+             :from_granddad,
+             patient:,
+             campaign: session.campaign
+    end
+    let(:triage) do
+      create :triage, patient:, campaign: session.campaign, notes: nil
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("p:first", text: "Triage complete - no notes")
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "health question is yes and triage is done with notes" do
+    let(:health_questions) do
+      [
+        {
+          question: "Is there anything else we should know?",
+          response: "yes",
+          notes: "These are notes"
+        }
+      ]
+    end
+    let(:triage_notes) { "These are triage notes" }
+    let(:triage) do
+      create :triage, patient:, campaign: session.campaign, notes: triage_notes
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("h2:nth(2)", text: "Triage notes")
+      expect(page).to have_css("p:first", text: triage_notes)
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "health question is yes and triage is done without notes" do
+    let(:health_questions) do
+      [
+        {
+          question: "Is there anything else we should know?",
+          response: "yes",
+          notes: "These are notes"
+        }
+      ]
+    end
+    let(:triage) do
+      create :triage, patient:, campaign: session.campaign, notes: nil
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("p:first", text: "Triage complete - no notes")
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "health question is yes but triage is not done" do
+    let(:health_questions) do
+      [
+        {
+          question: "Is there anything else we should know?",
+          response: "yes",
+          notes: "These are notes"
+        }
+      ]
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("p:first", text: "Triage needed")
+      expect(page).to have_css("li:first", text: "Notes need triage")
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+
+  context "health question is yes and parent is other but triage is not done" do
+    let(:health_questions) do
+      [
+        {
+          question: "Is there anything else we should know?",
+          response: "yes",
+          notes: "These are notes"
+        }
+      ]
+    end
+    let(:consent_response) do
+      create :consent_response,
+             :from_granddad,
+             patient:,
+             campaign: session.campaign,
+             health_questions:
+    end
+
+    it "renders correctly" do
+      expect(page).to have_css("p:first", text: "Triage needed")
+      expect(page).to have_css("li", text: "Check parental responsibility")
+      expect(page).to have_css("li", text: "Notes need triage")
+      expect(page).to have_css("h2", text: "Medical history answers")
+      expect(page).to have_css(
+        ".nhsuk-details__summary-text",
+        text: "Show answers"
+      )
+    end
+  end
+end

--- a/spec/factories/consent_responses.rb
+++ b/spec/factories/consent_responses.rb
@@ -85,5 +85,10 @@ FactoryBot.define do
       consent { :refused }
       reason_for_refusal { :personal_choice }
     end
+
+    trait :from_granddad do
+      parent_relationship { "other" }
+      parent_relationship_other { "Granddad" }
+    end
   end
 end


### PR DESCRIPTION
This component, primarily for the vaccination history page, encapsulates the logic for displaying triage information. The logic is intricate enough to warrant it's own component and a couple helper methods in models; the tests attempt to be thorough at the cost of increasing spec runtime.

This component has to address specific cases, here are a few examples of the changes:

### Patient with consent that doesn't need triage

#### Before 

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/6c7a2ceb-e4c4-4faf-8775-11c24a200e1d)

#### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/fc1fecb3-2ca4-48b4-a946-7c221bd7df2a)

### Patient with affirmative health question responses that hasn't been triaged yet

#### Before

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/a5a06571-d34e-421f-9919-40b4f9fe9db6)


#### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/420ee3d6-a5eb-451e-9751-2b54910b8a99)


### Patient with affirmative health question responses that has been triaged

#### Before

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/a80309d9-3492-47a0-85ec-9fa883ecbbb3)

#### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/85753aab-5dcd-4162-9fde-a9e421dba76d)

