### PR TITLE
Triage success flash

### DIFF
--- a/app/components/app_flash_success_component.html.erb
+++ b/app/components/app_flash_success_component.html.erb
@@ -1,0 +1,8 @@
+<%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
+  <% if title.present? %>
+    <% nb.with_heading(text: title) %>
+    <p><%= body.html_safe %></p>
+  <% else %>
+    <% nb.with_heading(text: body) %>
+  <% end %>
+<% end %>

--- a/app/components/app_flash_success_component.rb
+++ b/app/components/app_flash_success_component.rb
@@ -1,0 +1,15 @@
+class AppFlashSuccessComponent < ViewComponent::Base
+  attr_reader :body, :title
+
+  def initialize(flash_success)
+    super
+
+    if flash_success.is_a?(Hash)
+      @body = flash_success["body"]
+      @title = flash_success["title"]
+    else
+      @body = flash_success
+      @title = nil
+    end
+  end
+end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -34,7 +34,17 @@ class TriageController < ApplicationController
   def create
     @triage = Triage.new(campaign: @session.campaign, patient: @patient)
     if @triage.update(triage_params)
-      redirect_to triage_session_path(@session)
+      redirect_to triage_session_path(@session),
+                  flash: {
+                    success: {
+                      title: "Record saved for #{@patient.full_name}",
+                      body:
+                        ActionController::Base.helpers.link_to(
+                          "View child record",
+                          session_patient_triage_path(@session, @patient)
+                        )
+                    }
+                  }
     else
       render :show, status: :unprocessable_entity
     end
@@ -43,7 +53,17 @@ class TriageController < ApplicationController
   def update
     @triage = @patient.triage_for_campaign(@session.campaign)
     if @triage.update(triage_params)
-      redirect_to triage_session_path(@session)
+      redirect_to triage_session_path(@session),
+                  flash: {
+                    success: {
+                      title: "Record saved for #{@patient.full_name}",
+                      body:
+                        ActionController::Base.helpers.link_to(
+                          "View child record",
+                          session_patient_triage_path(@session, @patient)
+                        )
+                    }
+                  }
     else
       render :show, status: :unprocessable_entity
     end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -43,7 +43,14 @@ class VaccinationsController < ApplicationController
     end
     redirect_to session_vaccinations_path(@session),
                 flash: {
-                  success: "Record saved"
+                  success: {
+                    title: "Record saved for #{@patient.full_name}",
+                    body:
+                      ActionController::Base.helpers.link_to(
+                        "View child record",
+                        session_vaccination_path(@session, @patient)
+                      )
+                  }
                 }
   end
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,12 +1,5 @@
 <% if flash[:success].present? %>
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success][:title]) %>
-      <p><%= flash[:success][:body] %></p>
-    <% else %>
-      <% nb.with_heading(text: flash[:success]) %>
-    <% end %>
-  <% end %>
+  <%= render AppFlashSuccessComponent.new(flash[:success]) %>
 <% end %>
 
 <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,12 +1,5 @@
 <% if flash[:success].present? %>
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success][:title]) %>
-      <p><%= flash[:success][:body] %></p>
-    <% else %>
-      <% nb.with_heading(text: flash[:success]) %>
-    <% end %>
-  <% end %>
+  <%= render AppFlashSuccessComponent.new(flash[:success]) %>
 <% end %>
 
 <% content_for :before_main do %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -1,8 +1,8 @@
 <% if flash[:success].present? %>
   <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
     <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success][:title]) %>
-      <p><%= flash[:success][:body] %></p>
+      <% nb.with_heading(text: flash[:success]["title"]) %>
+      <p><%= flash[:success]["body"].html_safe %></p>
     <% else %>
       <% nb.with_heading(text: flash[:success]) %>
     <% end %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -1,12 +1,5 @@
 <% if flash[:success].present? %>
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success]["title"]) %>
-      <p><%= flash[:success]["body"].html_safe %></p>
-    <% else %>
-      <% nb.with_heading(text: flash[:success]) %>
-    <% end %>
-  <% end %>
+  <%= render AppFlashSuccessComponent.new(flash[:success]) %>
 <% end %>
 
 <% content_for :before_main do %>

--- a/app/views/triage/show.html.erb
+++ b/app/views/triage/show.html.erb
@@ -1,12 +1,5 @@
 <% if flash[:success].present? %>
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success][:title]) %>
-      <p><%= flash[:success][:body] %></p>
-    <% else %>
-      <% nb.with_heading(text: flash[:success]) %>
-    <% end %>
-  <% end %>
+  <%= render AppFlashSuccessComponent.new(flash[:success]) %>
 <% end %>
 
 <% content_for :before_main do %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -1,8 +1,8 @@
 <% if flash[:success].present? %>
   <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
     <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success][:title]) %>
-      <p><%= flash[:success][:body] %></p>
+      <% nb.with_heading(text: flash[:success]["title"]) %>
+      <p><%= flash[:success]["body"].html_safe %></p>
     <% else %>
       <% nb.with_heading(text: flash[:success]) %>
     <% end %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -1,12 +1,5 @@
 <% if flash[:success].present? %>
-  <%= govuk_notification_banner(title_text: "Success", success: true) do |nb| %>
-    <% if flash[:success].is_a?(Hash) %>
-      <% nb.with_heading(text: flash[:success]["title"]) %>
-      <p><%= flash[:success]["body"].html_safe %></p>
-    <% else %>
-      <% nb.with_heading(text: flash[:success]) %>
-    <% end %>
-  <% end %>
+  <%= render AppFlashSuccessComponent.new(flash[:success]) %>
 <% end %>
 
 <% content_for :before_main do %>

--- a/spec/components/app_flash_success_component_spec.rb
+++ b/spec/components/app_flash_success_component_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe AppFlashSuccessComponent, type: :component do
+  subject { described_class.new(flash_success) }
+
+  let(:component) { described_class.new(flash_success) }
+  let(:flash_success) { nil }
+
+  context "when flash_success is a hash" do
+    let(:flash_success) { { "body" => "Flash body", "title" => "Flash title" } }
+
+    it "assigns body and title correctly" do
+      expect(subject.body).to eq(flash_success["body"])
+      expect(subject.title).to eq(flash_success["title"])
+    end
+
+    describe "rendered page" do
+      before { render_inline(component) }
+
+      subject { page }
+
+      it "renders flash_success with title" do
+        expect(page).to have_css(
+          ".govuk-notification-banner__heading",
+          text: flash_success["title"]
+        )
+        expect(page).to have_css("p", text: flash_success["body"])
+      end
+    end
+  end
+
+  context "when flash_success is a string" do
+    let(:flash_success) { "Flash message" }
+
+    it "assigns body correctly" do
+      expect(subject.body).to eq(flash_success)
+      expect(subject.title).to be_nil
+    end
+
+    describe "rendered page" do
+      before { render_inline(component) }
+
+      subject { page }
+
+      it "renders flash_success without title" do
+        expect(page).to have_css(
+          ".govuk-notification-banner__heading",
+          text: flash_success
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes flash messages on triage and vaccination pages.

Also adds a component to keep the implementation in line across pages.

Various pages have been updated to use the new component, including pages that may not actually be using flash messages anymore. Those pages haven't been tested (e.g TriageController#show ... after a cursory look wasn't sure how to trigger that), but the flash message has been left in. I'd be interested in other's opinions on whether to keep those.

## Vaccination Success

### Before

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/e5386ce2-174d-4ee8-aaba-2ccc2813307e)

### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/9ff9e128-8424-48d4-9381-ae26a1d99571)


## Triage Success

### Before

no flash message


### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/ff9e728f-9d7b-4b34-b30d-5774ea6ffd32)
