### PR TITLE
More improvements to child page banners

### DIFF
--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -3,6 +3,7 @@ class TriageController < ApplicationController
   before_action :set_patient, only: %i[show create update]
   before_action :set_triage, only: %i[show]
   before_action :set_consent_response, only: %i[show]
+  before_action :set_vaccination_record, only: %i[show]
 
   layout "two_thirds"
 
@@ -68,6 +69,14 @@ class TriageController < ApplicationController
   def set_consent_response
     @consent_response =
       @patient.consent_response_for_campaign(@session.campaign)
+  end
+
+  def set_vaccination_record
+    @vaccination_record =
+      @patient
+        .vaccination_records_for_session(@session)
+        .where.not(recorded_at: nil)
+        .first
   end
 
   def triage_params

--- a/app/views/triage/_patient_triage.html.erb
+++ b/app/views/triage/_patient_triage.html.erb
@@ -2,6 +2,8 @@
   <%= patient.full_name %>
 </h1>
 
+<%= render "vaccinations/banners" %>
+
 <div class="nhsuk-card" id="consent">
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">

--- a/app/views/vaccinations/_banners.html.erb
+++ b/app/views/vaccinations/_banners.html.erb
@@ -25,3 +25,12 @@
               colour: "yellow"
             ) %>
 <% end %>
+
+<% if @triage&.do_not_vaccinate? %>
+  <%= render AppBannerComponent.new(
+              title: "Do not vaccinate",
+              # TODO replace "The nurse" with the nurse's full name when that information is available
+              explanation: "The nurse has decided that #{@triage.patient.full_name} should not be vaccinated",
+              colour: "red"
+          ) %>
+<% end %>

--- a/app/views/vaccinations/_banners.html.erb
+++ b/app/views/vaccinations/_banners.html.erb
@@ -1,0 +1,27 @@
+<% if @vaccination_record&.administered? %>
+  <%= render AppBannerComponent.new(
+                title: "Vaccinated",
+                explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
+                colour: "green"
+              ) %>
+<% elsif @vaccination_record&.administered == false %>
+  <%= render AppBannerComponent.new(
+                title: "Could not vaccinate",
+                # TODO: add reason for refusal once that is collected
+                explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
+                colour: "orange"
+              ) %>
+<% end %>
+
+<% if @consent_response&.consent_refused? %>
+  <%= render AppBannerComponent.new(
+          title: "Their #{@consent_response.who_responded.downcase} has refused to give consent",
+          colour: "orange"
+        ) %>
+
+<% elsif @consent_response.nil? %>
+  <%= render AppBannerComponent.new(
+              title: "No-one responded to our requests for consent",
+              colour: "yellow"
+            ) %>
+<% end %>

--- a/app/views/vaccinations/_patient.html.erb
+++ b/app/views/vaccinations/_patient.html.erb
@@ -2,30 +2,10 @@
   <%= patient.full_name %>
 </h1>
 
-<% if @vaccination_record&.administered? %>
-  <%= render AppBannerComponent.new(
-                title: "Vaccinated",
-                explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
-                colour: "green"
-              ) %>
-<% elsif @vaccination_record&.administered == false %>
-  <%= render AppBannerComponent.new(
-                title: "Could not vaccinate",
-                # TODO: add reason for refusal once that is collected
-                explanation: @consent_response.present? ? "Their #{@consent_response.who_responded.downcase} gave consent" : "",
-                colour: "orange"
-              ) %>
-<% end %>
+<%= render "banners" %>
 
 <div data-controller="child-vaccination">
   <% if @consent_response.present? %>
-    <% if @consent_response.consent_refused? %>
-      <%= render AppBannerComponent.new(
-              title: "Their #{@consent_response.who_responded.downcase} has refused to give consent",
-              colour: "orange"
-            ) %>
-    <% end %>
-
     <div class="nhsuk-card" id="consent">
       <div class="nhsuk-card__content">
         <h2 class="nhsuk-card__heading nhsuk-heading-m">
@@ -35,12 +15,7 @@
         <%= render "triage/patient_triage_consent_response", consent_response: @consent_response %>
       </div>
     </div>
-    <% else %>
-      <%= render AppBannerComponent.new(
-                  title: "No-one responded to our requests for consent",
-                  colour: "yellow"
-                ) %>
-    <% end %>
+  <% end %>
 
   <%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
 


### PR DESCRIPTION
* Add a banner for patients where triage determined "do not vaccinate"

<img width="719" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/1a129512-aee3-41b9-b9aa-a8a097fda732">

* pull all banner code into a partial
* display the same banners consistently between record and triage child pages