### PR TITLE
Don't show site when vaccination was not administered

### DIFF
--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -35,7 +35,7 @@
         end
       else
         summary_list.with_row do |row|
-          row.with_key { 'Site' }
+          row.with_key { 'Reason' }
           row.with_value { 'Not administered' }
         end
       end


### PR DESCRIPTION
Instead, show a reason. Adding a reason is coming in a follow-up PR.

### Administered

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/3419e098-32cb-4f18-8ab2-6db1b6a24696)

### Not administered

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/3703a3fc-a544-4242-8e88-78af4139f192)
