### PR TITLE
Triage reason on index page

### DIFF
--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -12,7 +12,7 @@ class TriageController < ApplicationController
     @patient_details =
       @session
         .patient_sessions
-        .includes(:patient)
+        .includes(:vaccination_records, patient: %i[consent_responses triage])
         .order("patients.first_name", "patients.last_name")
         .map do |ps|
           consent = ps.patient.consent_response_for_campaign(@session.campaign)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -57,11 +57,11 @@ class Patient < ApplicationRecord
   end
 
   def triage_for_campaign(campaign)
-    triage.find_by(campaign:)
+    triage.to_a.find { |t| t.campaign_id == campaign.id }
   end
 
   def consent_response_for_campaign(campaign)
-    consent_responses.find_by(campaign:)
+    consent_responses.to_a.find { |t| t.campaign_id == campaign.id }
   end
 
   def as_json(options = {})

--- a/app/views/triage/_patient_row.html.erb
+++ b/app/views/triage/_patient_row.html.erb
@@ -2,8 +2,17 @@
   <td class="govuk-table__cell">
     <%= link_to patient.full_name, session_patient_triage_path(@session, patient), "data-testid": "child-link" %>
   </td>
-  <td class="govuk-table__cell" style="width: 150px">
-    <%= patient.dob.to_fs(:nhsuk_date_short_month) %>
+  <td class="govuk-table__cell">
+    <%
+    if %i[triage needs_follow_up].include? action_or_outcome[:action]
+      consent_response = patient.consent_response_for_campaign(@session.campaign)
+      %>
+      <ul class="nhsuk-list nhsuk-u-margin-bottom-2">
+        <% consent_response.reasons_triage_needed.map do |reason| %>
+          <li><%= reason %></li>
+        <% end %>
+      </ul>
+    <% end %>
   </td>
   <td class="govuk-table__cell" data-testid="child-action">
     <% label = PatientSession.human_enum_name("actions_or_outcome", action_or_outcome[:action] || action_or_outcome[:outcome]) %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -17,7 +17,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Name</th>
-        <th class="govuk-table__header">Date of birth</th>
+        <th class="govuk-table__header">Triage reason</th>
         <th class="govuk-table__header">Action needed</th>
       </tr>
     </thead>

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -99,6 +99,7 @@ const patients = {
   "Archie Simonis": {
     row: 9,
     note: "",
+    triage_reasons: ["Notes need triage"],
     status: "Triage",
     status_colour: "blue",
     banner_title: "Triage needed",
@@ -205,6 +206,15 @@ async function then_i_should_see_a_triage_row_for_the_patient(
     p.locator(`#patients tr:nth-child(${patient.row}) td:first-child`),
     `Name for patient row: ${patient.row} name: ${name}`
   ).toContainText(name);
+
+  if (patient.triage_reasons) {
+    for (let reason of patient.triage_reasons) {
+      await expect(
+        p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(2)`),
+        `Triage reason for patient row: ${patient.row} name: ${name}`
+      ).toContainText(reason);
+    }
+  }
 
   await expect(
     p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(3)`),

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -8,7 +8,7 @@ const patients = {
     row: 1,
     note: "",
     status: "Vaccinate",
-    class: "nhsuk-tag--purple",
+    status_colour: "purple",
     consent_response: "Given by",
     parent_name: "Betty Pfeffer",
     parent_email: "Betty_Pfeffer62@yahoo.com",
@@ -19,7 +19,7 @@ const patients = {
     row: 2,
     note: "",
     status: "Vaccinate",
-    class: "nhsuk-tag--purple",
+    status_colour: "purple",
     consent_response: "Given by",
     parent_name: "Garret Lakin",
     parent_email: "Garret57@hotmail.com",
@@ -30,7 +30,7 @@ const patients = {
     row: 3,
     note: "Notes from nurse",
     status: "Vaccinate",
-    class: "nhsuk-tag--purple",
+    status_colour: "purple",
     consent_response: "Given by",
     parent_name: "Georgianna Kshlerin",
     parent_email: "Georgianna.Kshlerin0@hotmail.com",
@@ -41,8 +41,7 @@ const patients = {
     row: 4,
     note: "",
     status: "Do not vaccinate",
-    class: "nhsuk-tag--red",
-    banner_colour_class: "app-consent-banner--red",
+    status_colour: "red",
     banner_title: "Do not vaccinate",
     banner_content: [
       "The nurse has decided that Amalia Wiza should not be vaccinated",
@@ -57,7 +56,7 @@ const patients = {
     row: 5,
     note: "Notes from nurse",
     status: "Do not vaccinate",
-    class: "nhsuk-tag--red",
+    status_colour: "red",
     consent_response: "Given by",
     parent_relationship: "Mother",
     parent_name: "Reese Klein",
@@ -68,8 +67,7 @@ const patients = {
     row: 6,
     note: "",
     status: "Triage: follow up",
-    class: "nhsuk-tag--aqua-green",
-    banner_colour_class: "app-consent-banner--aqua-green",
+    status_colour: "aqua-green",
     banner_title: "Triage follow-up needed",
     consent_response: "Given by",
     parent_relationship: "Father",
@@ -81,8 +79,7 @@ const patients = {
     row: 7,
     note: "",
     status: "Get consent",
-    class: "nhsuk-tag--yellow",
-    banner_colour_class: "app-consent-banner--yellow",
+    status_colour: "yellow",
     banner_title: "No-one responded to our requests for consent",
     consent_response: "No response given",
   },
@@ -90,8 +87,7 @@ const patients = {
     row: 8,
     note: "",
     status: "Check refusal",
-    class: "nhsuk-tag--orange",
-    banner_colour_class: "app-consent-banner--orange",
+    status_colour: "orange",
     banner_title: "Their father has refused to give consent",
     consent_response: "Refused by",
     reason_for_refusal: "Personal choice",
@@ -104,8 +100,7 @@ const patients = {
     row: 9,
     note: "",
     status: "Triage",
-    class: "nhsuk-tag--blue",
-    banner_colour_class: "app-consent-banner--blue",
+    status_colour: "blue",
     banner_title: "Triage needed",
     banner_content: ["Notes need triage"],
     consent_response: "Given by",
@@ -143,7 +138,7 @@ test("Performing triage", async ({ page }) => {
   await then_i_should_see_a_triage_row_for_the_patient("Aaron Pfeffer", {
     note: "Notes from nurse",
     status: "Do not vaccinate",
-    class: "nhsuk-tag--red",
+    status_colour: "red",
   });
 
   await when_i_click_on_the_patient("Aaron Pfeffer");
@@ -153,7 +148,7 @@ test("Performing triage", async ({ page }) => {
   await then_i_should_see_a_triage_row_for_the_patient("Aaron Pfeffer", {
     note: null,
     status: "Vaccinate",
-    class: "nhsuk-tag--purple",
+    status_colour: "purple",
   });
 });
 
@@ -216,10 +211,11 @@ async function then_i_should_see_a_triage_row_for_the_patient(
     `Status text for patient row: ${patient.row} name: ${name}`
   ).toContainText(patient.status);
 
+  let colourClass = "nhsuk-tag--" + patient.status_colour;
   await expect(
     p.locator(`#patients tr:nth-child(${patient.row}) td:nth-child(3) div`),
     `Status colour for patient row: ${patient.row} name: ${name}`
-  ).toHaveClass(new RegExp(patient.class));
+  ).toHaveClass(new RegExp(colourClass));
 }
 
 async function then_i_should_see_the_triage_page_for_the_patient(name) {
@@ -230,16 +226,15 @@ async function then_i_should_see_the_triage_page_for_the_patient(name) {
 async function and_i_should_see_a_banner_for_the_patient(name) {
   let patient = patients[name];
   let title = patient["banner_title"];
-  let colourClass = patient["banner_colour_class"];
+  let colourClass = "app-consent-banner--" + patient["status_colour"];
   let content = patient["banner_content"];
 
-  if (colourClass != null)
-    await expect(p.locator("div.app-consent-banner")).toHaveClass(
-      new RegExp(colourClass)
-    );
+  if (title == null) return;
 
-  if (title != null)
-    await expect(p.locator(".app-consent-banner > span")).toHaveText(title);
+  await expect(p.locator(".app-consent-banner > span")).toHaveText(title);
+  await expect(p.locator("div.app-consent-banner")).toHaveClass(
+    new RegExp(colourClass)
+  );
 
   if (content != null)
     for (let text of content) await expect(p.getByText(text)).toBeVisible();


### PR DESCRIPTION
Replaces the date of birth, as per designs. A little bit janky in the current state because we don't filter on the triage page, and we have a "Needs follow-up" record that doesn't have any good reason to need follow-up, but these should be tidied up as part of other work.

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/b0b9c1be-ca1f-49de-bec2-8e17e64dd6f2)
