### PR TITLE
Use a two_thirds layout for the ConsentController

### DIFF
--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -5,6 +5,8 @@ class TriageController < ApplicationController
   before_action :set_consent_response, only: %i[show]
   before_action :set_vaccination_record, only: %i[show]
 
+  layout "two_thirds", except: %i[index]
+
   def index
     @session = Session.find_by(id: params[:id])
     @patient_details =


### PR DESCRIPTION
The index needs full-width, but it's safe to assume that most of the actions should display with a two_thirds layout, mimicking vaccinations_controller.rb