### PR TITLE
Reposition medical history below medical answers

### DIFF
--- a/app/components/app_patient_medical_history_card_component.html.erb
+++ b/app/components/app_patient_medical_history_card_component.html.erb
@@ -4,6 +4,20 @@
       Medical history
     </h2>
 
+    <% if @consent_response.health_questions.present? %>
+      <details class="nhsuk-details nhsuk-expander">
+        <summary class="nhsuk-details__summary">
+          <span class="nhsuk-details__summary-text">
+            Show answers
+          </span>
+        </summary>
+
+        <div class="nhsuk-details__text">
+          <%= render AppHealthQuestionsComponent.new(consent_response: @consent_response) %>
+        </div>
+      </details>
+    <% end %>
+
     <% if @consent_response.triage_needed? %>
       <% if triage_present? %>
         <p>Triage needed</p>
@@ -28,21 +42,6 @@
 
     <% else %>
       <p>No triage needed</p>
-    <% end %>
-
-    <% if @consent_response.health_questions.present? %>
-      <details class="nhsuk-details nhsuk-expander nhsuk-u-margin-bottom-0">
-        <summary class="nhsuk-details__summary">
-          <span class="nhsuk-details__summary-text">
-            Show answers
-          </span>
-        </summary>
-
-        <div class="nhsuk-details__text">
-          <%= render AppHealthQuestionsComponent.new(consent_response: @consent_response) %>
-        </div>
-      </details>
-
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
The notes appeared to get ignored in research if they are before the answers in the reading order.

### Before

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/b55ffdd4-f358-4323-ad57-67929ca5d112)

### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/4130ab1a-7aa9-420c-9390-ec2fdfec6247)
