### PR TITLE
Add absent_from_school and absent_from_session reasons

### DIFF
--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -54,8 +54,10 @@ module VaccinationsHelper
       "#{record.patient_session.patient.full_name} had contraindications"
     when "already_had"
       "#{record.patient_session.patient.full_name} has already had the vaccine"
-    when "absent"
-      "#{record.patient_session.patient.full_name} was absent"
+    when "absent_from_school"
+      "#{record.patient_session.patient.full_name} was absent from school"
+    when "absent_from_session"
+      "#{record.patient_session.patient.full_name} was absent from the session"
     else
       "Unknown"
     end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -23,7 +23,15 @@ class VaccinationRecord < ApplicationRecord
   belongs_to :patient_session
 
   enum :site, %i[left_arm right_arm other]
-  enum :reason, %i[refused not_well contraindications already_had absent]
+  enum :reason,
+       %i[
+         refused
+         not_well
+         contraindications
+         already_had
+         absent_from_school
+         absent_from_session
+       ]
 
   validates :administered, inclusion: [true, false]
   validates :site,

--- a/app/views/vaccinations/reason.html.erb
+++ b/app/views/vaccinations/reason.html.erb
@@ -22,8 +22,10 @@
         label: { text: 'They had contraindications' } %>
       <%= f.govuk_radio_button :reason, "already_had",
         label: { text: 'They have already had the vaccine' } %>
-      <%= f.govuk_radio_button :reason, "absent",
-        label: { text: 'They were absent' } %>
+      <%= f.govuk_radio_button :reason, "absent_from_school",
+        label: { text: 'They were absent from school' } %>
+      <%= f.govuk_radio_button :reason, "absent_from_session",
+        label: { text: 'They were absent from the session' } %>
     <% end %>
   <%= f.submit "Continue", class: "nhsuk-button" %>
 <% end %>


### PR DESCRIPTION
These were pointed out as more descriptive than simply "absent" in the model office session.

The old `absent` state should automatically match the new `absent_from_school` state by virtue of having the same position in the enum.

### New reasons

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/6c209712-9338-4b3b-9d9f-8eb33c0b3550)
