### PR TITLE
Remove medical history notes heading

### DIFF
--- a/app/components/app_patient_medical_history_card_component.html.erb
+++ b/app/components/app_patient_medical_history_card_component.html.erb
@@ -35,11 +35,6 @@
           <p>Triage complete - no notes</p>
         <% end %>
       <% end %>
-
-      <% if @consent_response.health_questions.present? %>
-        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Medical history answers</h2>
-      <% end %>
-
     <% else %>
       <p>No triage needed</p>
     <% end %>

--- a/spec/components/app_patient_medical_history_card_component_spec.rb
+++ b/spec/components/app_patient_medical_history_card_component_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage needed")
       expect(page).to have_css("li", text: "Check parental responsibility")
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"
@@ -72,7 +71,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
     it "renders correctly" do
       expect(page).to have_css("h2:nth(2)", text: "Triage notes")
       expect(page).to have_css("p:first", text: triage_notes)
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"
@@ -93,7 +91,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
 
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage complete - no notes")
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"
@@ -119,7 +116,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
     it "renders correctly" do
       expect(page).to have_css("h2:nth(2)", text: "Triage notes")
       expect(page).to have_css("p:first", text: triage_notes)
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"
@@ -143,7 +139,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
 
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage complete - no notes")
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"
@@ -165,7 +160,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage needed")
       expect(page).to have_css("li:first", text: "Notes need triage")
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"
@@ -195,7 +189,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
       expect(page).to have_css("p:first", text: "Triage needed")
       expect(page).to have_css("li", text: "Check parental responsibility")
       expect(page).to have_css("li", text: "Notes need triage")
-      expect(page).to have_css("h2", text: "Medical history answers")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"


### PR DESCRIPTION
The triage notes have been moved underneath the health questions, so this heading isn't necessary anymore.