### PR TITLE
Fix nhsuk-error-summary

### DIFF
--- a/app/javascript/controllers/govuk_error_summary_controller.js
+++ b/app/javascript/controllers/govuk_error_summary_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-import { ErrorSummary } from "govuk-frontend";
-
-// Connects to data-module="govuk-error-summary"
-export default class extends Controller {
-  connect() {
-    new ErrorSummary(this.element).init();
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,9 +19,6 @@ application.register("govuk-checkboxes", GovukCheckboxesController);
 import GovukDetailsController from "./govuk_details_controller";
 application.register("govuk-details", GovukDetailsController);
 
-import GovukErrorSummaryController from "./govuk_error_summary_controller";
-application.register("govuk-error-summary", GovukErrorSummaryController);
-
 import GovukHeaderController from "./govuk_header_controller";
 application.register("govuk-header", GovukHeaderController);
 
@@ -33,6 +30,9 @@ application.register(
 
 import GovukSkipLinkController from "./govuk_skip_link_controller";
 application.register("govuk-skip-link", GovukSkipLinkController);
+
+import NhsukErrorSummaryController from "./nhsuk_error_summary_controller";
+application.register("nhsuk-error-summary", NhsukErrorSummaryController);
 
 import NhsukRadiosController from "./nhsuk_radios_controller";
 application.register("nhsuk-radios", NhsukRadiosController);

--- a/app/javascript/controllers/nhsuk_error_summary_controller.ts
+++ b/app/javascript/controllers/nhsuk_error_summary_controller.ts
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus";
+import ErrorSummary from "nhsuk-frontend/packages/components/error-summary/error-summary";
+
+// Connects to data-module="nhsuk-error-summary"
+export default class extends Controller {
+  connect() {
+    this.shimFocusBehaviour();
+
+    ErrorSummary();
+  }
+
+  // Because we're using the GOVUK Error Summary HTML, the server-rendered
+  // element does not have tabindex=-1 set by default, which is required for
+  // the initial focus to work. GOVUK Frontend also removes the tabindex
+  // attribute on blur, as it doesn't need to be focused again.
+  //
+  // Based on https://github.com/alphagov/govuk-frontend/blob/91d0a5d8b694875b34eb4be52ecf155f8b3701d0/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs#L58-L64
+  shimFocusBehaviour() {
+    this.element.setAttribute("tabindex", "-1");
+
+    this.element.addEventListener("blur", () => {
+      this.element.removeAttribute("tabindex");
+    });
+  }
+}


### PR DESCRIPTION
The summary isn't getting focused because the GOVUK Error Summary JS doesn't match the NHSUK Frontend HTML.

### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/6f2b7f08-150b-4071-aad4-ce0d87a57f7a)
