### PR TITLE
Fix vaccinations table title in mobile view

### DIFF
--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -13,7 +13,7 @@
 <h1>Record vaccinations</h1>
 
 <%=
-govuk_tabs title: "Vax", classes: 'nhsuk-tabs' do |c|
+govuk_tabs title: "Vaccinations", classes: 'nhsuk-tabs' do |c|
   c.with_tab(label: "Action needed", classes: 'nhsuk-tabs__panel') do
     render "patients_with_actions",
            id: "action-needed",


### PR DESCRIPTION
This title is only visible on mobiles.

## Before

<img width="432" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/be939efc-03fd-4f90-a00c-9e749dd15fec">

## After

<img width="400" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/9c380e60-4224-486b-812e-4b1174fcc490">
