### PR TITLE
Remove unused helper code

### DIFF
--- a/app/helpers/patient_session_helper.rb
+++ b/app/helpers/patient_session_helper.rb
@@ -23,7 +23,6 @@ module PatientSessionHelper
       colour: "red",
       text: "Do not vaccinate",
       banner_title: "Do not vaccinate",
-      banner_explanation: "The nurse has decided that %{full_name} should not be vaccinated",
     },
     triaged_kept_in_triage: {
       colour: "aqua-green",
@@ -38,13 +37,11 @@ module PatientSessionHelper
       colour: "orange",
       text: "Unable to vaccinate",
       banner_title: "Could not vaccinate",
-      banner_explanation: "Their %{who_responded} gave consent",
     },
     vaccinated: {
       colour: "green",
       text: "Vaccinated",
       banner_title: "Vaccinated",
-      banner_explanation: "Their %{who_responded} gave consent",
     },
   }.with_indifferent_access.freeze
 
@@ -59,10 +56,5 @@ module PatientSessionHelper
   def banner_title_for_state(state, params = {})
     return unless STATUS_COLOURS_AND_TEXT[state].key? :banner_title
     STATUS_COLOURS_AND_TEXT[state][:banner_title] % params
-  end
-
-  def banner_explanation_for_state(state, params = {})
-    return unless STATUS_COLOURS_AND_TEXT[state].key? :banner_explanation
-    STATUS_COLOURS_AND_TEXT[state][:banner_explanation] % params
   end
 end


### PR DESCRIPTION
Found while investigating something else.

The helper method `banner_explanation_for_state` isn't referenced anywhere, and the `banner_explanation` key in `STATUS_COLOURS_AND_TEXT` isn't referenced anywhere other than the deleted helper method, as far as I can tell.