### PR TITLE
Banner bugfix when patient ready to vaccinate without triage

### DIFF
--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -12,7 +12,6 @@ en:
       colour: purple
       text: Vaccinate
       banner_title: Ready to vaccinate
-      banner_explanation: Jane Doe decided that %{full_name} can be vaccinated.
     consent_refused:
       colour: orange
       text: Check refusal

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     it { should have_css(".app-consent-banner--purple") }
     it { should have_text("Ready to vaccinate") }
     it 'does not provide an explanation as no triage took place' do
-      expect(component.explanation).to eq('Jane Doe decided that Alya Merton can be vaccinated.')
+      expect(component.explanation).to be_blank
     end
   end
 

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
   subject { page }
 
+  before do
+    patient_session.patient.update!(first_name: "Alya", last_name: "Merton")
+  end
+
   context "state is added_to_session" do
     let(:patient_session) { create :patient_session, :added_to_session }
 
@@ -19,7 +23,9 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--purple") }
     it { should have_text("Ready to vaccinate") }
-    # banner_explanation: Jane Doe decided that %{full_name} can be vaccinated.
+    it 'does not provide an explanation as no triage took place' do
+      expect(component.explanation).to eq('Jane Doe decided that Alya Merton can be vaccinated.')
+    end
   end
 
   context "state is consent_given_triage_needed" do
@@ -41,7 +47,9 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--red") }
     it { should have_text("Do not vaccinate") }
-    # banner_explanation: Jane Doe decided that %{full_name} should not be vaccinated.
+    it 'explains who took the decision that the patient should not be vaccinated' do
+      expect(component.explanation).to eq('Jane Doe decided that Alya Merton should not be vaccinated.')
+    end
   end
 
   context "state is triaged_kept_in_triage" do
@@ -56,7 +64,9 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--purple") }
     it { should have_text("Ready to vaccinate") }
-    # banner_explanation: Jane Doe decided that %{full_name} can be vaccinated.
+    it 'explains who took the decision that the patient should be vaccinated' do
+      expect(component.explanation).to eq('Jane Doe decided that Alya Merton can be vaccinated.')
+    end
   end
 
   context "state is unable_to_vaccinate" do
@@ -64,14 +74,9 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--orange") }
     it { should have_text("Could not vaccinate") }
-    # banner_explanation:
-    #   refused: "%{full_name} refused it"
-    #   now_well: "%{full_name} was not well enough"
-    #   contraindications: "%{full_name} had contraindications"
-    #   already_had: "%{full_name} has already had the vaccine"
-    #   absent_from_school: "%{full_name} was absent from school"
-    #   absent_from_session: "%{full_name} was absent from the session"
-    #   gave_consent: "Their %{who_responded} gave consent"
+    it 'explains who took the decision that the patient should be vaccinated' do
+      expect(component.explanation).to include('Alya Merton had contraindications')
+    end
   end
 
   context "state is vaccinated" do
@@ -79,6 +84,9 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--green") }
     it { should have_text("Vaccinated") }
-    # banner_explanation: Their %{who_responded} gave consent
+    it 'explains who gave consent' do
+      who_responded = patient_session.consent_response.who_responded
+      expect(component.explanation).to include("Their #{who_responded} gave consent")
+    end
   end
 end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -69,6 +69,13 @@ FactoryBot.define do
 
     trait :vaccinated do
       state { "vaccinated" }
+      patient { create :patient, :triaged_ready_to_vaccinate, session: }
+
+      after :create do |patient_session|
+        create :vaccination_record,
+               administered: true,
+               patient_session:
+      end
     end
   end
 end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -26,5 +26,6 @@ FactoryBot.define do
   factory :vaccination_record do
     patient_session { nil }
     recorded_at { "2023-06-09" }
+    site { "left_arm" }
   end
 end


### PR DESCRIPTION
## Context

There is consent and no contraindications, so the patient is ready to vaccinate:

<img width="424" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/be3f43a4-4d20-469a-919c-fa3fcec3cb33">

## What happens before the fix

According to the banner, a nurse has deemed the patient can be vaccinated. This isn't true as this record hasn't gone through triage:

<img width="463" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/10230a7e-ebd0-40bf-a5e9-256d89d12145">

## What happens after the fix

The description has been removed.

<img width="458" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/e5e27431-7fa0-43fb-9462-9b7bbb16ac83">


## Notes for reviewers

* Best reviewed commit-by-commit
* I've added extra spec coverage to `app_status_banner_component_spec`
