### PR TITLE
Handle journey where patient is not Gillick competent

### DIFF
--- a/app/components/app_gillick_card_component.html.erb
+++ b/app/components/app_gillick_card_component.html.erb
@@ -14,14 +14,21 @@
         <% end
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Gillick competent" }
-        row.with_value { @patient_session.gillick_competent? ? 'Yes' : 'No' }
-      end
+      if @patient_session.gillick_competent?
+        summary_list.with_row do |row|
+          row.with_key { "Gillick competent" }
+          row.with_value { 'Yes' }
+        end
 
-      summary_list.with_row do |row|
-        row.with_key { 'Consent' }
-        row.with_value { 'Given by child' }
+        summary_list.with_row do |row|
+          row.with_key { 'Consent' }
+          row.with_value { 'Given by child' }
+        end
+      else
+        summary_list.with_row do |row|
+          row.with_key { "Gillick competent" }
+          row.with_value { 'No' }
+        end
       end
     end %>
   </div>

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -13,6 +13,7 @@ module PatientSessionStateMachineConcern
       state :triaged_do_not_vaccinate
       state :triaged_kept_in_triage
       state :unable_to_vaccinate
+      state :unable_to_vaccinate_not_gillick_competent
       state :vaccinated
 
       event :do_consent do
@@ -27,6 +28,12 @@ module PatientSessionStateMachineConcern
         transitions from: :added_to_session,
                     to: :consent_refused,
                     if: :consent_refused?
+      end
+
+      event :do_gillick_assessment do
+        transitions from: :added_to_session,
+                    to: :unable_to_vaccinate_not_gillick_competent,
+                    if: :not_gillick_competent?
       end
 
       event :do_triage do
@@ -96,6 +103,10 @@ module PatientSessionStateMachineConcern
 
     def vaccination_not_administered?
       vaccination_record&.administered == false
+    end
+
+    def not_gillick_competent?
+      !gillick_competent?
     end
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -26,7 +26,6 @@ class PatientSession < ApplicationRecord
 
   validates :gillick_competent,
     inclusion: { in: [true, false] },
-    presence: true,
     on: :edit_gillick
   validates :gillick_competence_notes,
     presence: true,

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -54,7 +54,7 @@
           <%= f.govuk_radio_button :route, "self_consent",
             label: { text: 'Yes, I am assessing Gillick competence' } %>
           <%= f.govuk_radio_button :route, "not_provided",
-            label: { text: 'No' } %>
+            label: { text: 'No, I am not vaccinating' } %>
         <% end %>
 
         <%= f.submit "Continue", class: "nhsuk-button" %>

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -123,7 +123,8 @@
       </dl>
     </div>
   </div>
-<% elsif @vaccination_record.nil? %>
+<% elsif @vaccination_record.nil? &&
+  !@patient_session.unable_to_vaccinate_not_gillick_competent? %>
   <div class="nhsuk-card">
     <div class="nhsuk-card__content">
       <%= form_with model: @draft_vaccination_record,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,6 @@ en:
         patient_session:
           attributes:
             gillick_competent:
-              blank: Choose if they are Gillick competent
               inclusion: Choose if they are Gillick competent
             gillick_competence_notes:
               blank: Enter details of your assessment

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -42,6 +42,11 @@ en:
         absent_from_school: "%{full_name} was absent from school"
         absent_from_session: "%{full_name} was absent from the session"
         gave_consent: "Their %{who_responded} gave consent"
+    unable_to_vaccinate_not_gillick_competent:
+      colour: red
+      text: Not vaccinated
+      banner_title: Not vaccinated
+      banner_explanation: No-one responded to our requests for consent. When assessed, the child was not Gillick competent.
     vaccinated:
       colour: green
       text: Vaccinated

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe PatientSessionStateMachineConcern do
 
       def vaccination_record
       end
+
+      def gillick_competent?
+      end
     end
   end
 
@@ -66,6 +69,15 @@ RSpec.describe PatientSessionStateMachineConcern do
 
         fsm.do_consent
         expect(fsm).to be_consent_refused
+      end
+    end
+
+    describe "#do_gillick_assessment" do
+      it "transitions to unable_to_vaccinate_not_gillick_competent when patient is not gillick competent" do
+        allow(fsm).to receive(:gillick_competent?).and_return(false)
+
+        fsm.do_gillick_assessment
+        expect(fsm).to be_unable_to_vaccinate_not_gillick_competent
       end
     end
   end

--- a/tests/gillick.spec.ts
+++ b/tests/gillick.spec.ts
@@ -6,6 +6,7 @@ test("Records gillick consent", async ({ page }) => {
   p = page;
   await given_the_app_is_setup();
 
+  // Gillick competence passed
   await when_i_go_to_the_vaccinations_page();
   await then_i_see_the_patient_that_needs_consent();
 
@@ -35,6 +36,18 @@ test("Records gillick consent", async ({ page }) => {
 
   await when_i_click_confirm();
   await then_i_see_the_vaccination_show_page();
+
+  // Not Gillick competent
+  await when_i_go_to_the_vaccinations_page();
+  await when_i_click_on_the_second_patient();
+
+  await when_i_click_yes_gillick();
+  await and_i_click_continue();
+  await when_i_click_give_your_assessment();
+  await when_i_click_no_they_are_not_gillick_competent();
+  await and_i_give_details();
+  await and_i_click_continue();
+  await then_i_see_the_vaccination_show_page_for_the_second_patient();
 });
 
 async function given_the_app_is_setup() {
@@ -128,4 +141,16 @@ async function and_it_contains_gillick_assessment_details() {
   await expect(
     p.getByRole("heading", { name: "Gillick competence" }),
   ).toBeVisible();
+}
+
+async function when_i_click_on_the_second_patient() {
+  await p.click("text=Mariano Kuhic");
+}
+
+async function when_i_click_no_they_are_not_gillick_competent() {
+  await p.click("text=No");
+}
+
+async function then_i_see_the_vaccination_show_page_for_the_second_patient() {
+  await expect(p.locator("h1")).toContainText("Mariano Kuhic");
 }


### PR DESCRIPTION
Builds on https://github.com/nhsuk/record-childrens-vaccinations/pull/379.

This adds a new transition from the `added_to_session` state to the `unable_to_vaccinate_not_gillick_competent` state. It updates the controller when the consent_response is being updated so that it shortcuts to this state.

Best reviewed commit by commit.

### After

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/1bf1481d-cd6b-464f-a8e8-e1813adac26b)
