### PR TITLE
Use asdf node version in Jest CI run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Get Node.js version
+        id: asdf
+        run: echo "::set-output name=VERSION::$(grep nodejs .tool-versions | awk '{print $2}')"
       - uses: actions/setup-node@v3
         with:
+          node-version: ${{ steps.asdf.outputs.VERSION }}
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - run: yarn test


### PR DESCRIPTION
We're currently using the latest stable Node.js, which seems to have changed something TextDecoder related which now causes our Jest tests to fail. We should be using the one we specify in `.tool-versions`. `setup-node` does not pick it up automatically, but we can pick it up manually with `grep` and `awk`.