### PR TITLE
Handle "No, I am not vaccinating" journey

### DIFF
--- a/app/helpers/patient_session_helper.rb
+++ b/app/helpers/patient_session_helper.rb
@@ -38,6 +38,16 @@ module PatientSessionHelper
       text: "Unable to vaccinate",
       banner_title: "Could not vaccinate",
     },
+    unable_to_vaccinate_not_assessed: {
+      colour: "red",
+      text: "Not vaccinated",
+      banner_title: "Not vaccinated",
+    },
+    unable_to_vaccinate_not_gillick_competent: {
+      colour: "red",
+      text: "Not vaccinated",
+      banner_title: "Not vaccinated",
+    },
     vaccinated: {
       colour: "green",
       text: "Vaccinated",

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -13,6 +13,7 @@ module PatientSessionStateMachineConcern
       state :triaged_do_not_vaccinate
       state :triaged_kept_in_triage
       state :unable_to_vaccinate
+      state :unable_to_vaccinate_not_assessed
       state :unable_to_vaccinate_not_gillick_competent
       state :vaccinated
 
@@ -51,6 +52,10 @@ module PatientSessionStateMachineConcern
       end
 
       event :do_vaccination do
+        transitions from: :added_to_session,
+                    to: :unable_to_vaccinate_not_assessed,
+                    if: :no_consent?
+
         transitions from: :consent_given_triage_not_needed,
                     to: :vaccinated,
                     if: :vaccination_administered?
@@ -75,6 +80,10 @@ module PatientSessionStateMachineConcern
 
     def consent_refused?
       consent_response&.consent_refused?
+    end
+
+    def no_consent?
+      consent_response.nil?
     end
 
     def triage_needed?

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -42,4 +42,10 @@ class PatientSession < ApplicationRecord
   def vaccination_record
     vaccination_records.last
   end
+
+  def able_to_vaccinate?
+    !unable_to_vaccinate? &&
+    !unable_to_vaccinate_not_assessed? &&
+    !unable_to_vaccinate_not_gillick_competent?
+  end
 end

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -25,7 +25,7 @@ govuk_tabs title: "Vaccinations", classes: 'nhsuk-tabs' do |c|
   c.with_tab(label: "Not vaccinated", classes: 'nhsuk-tabs__panel') do
     render "patients_with_outcomes",
            id: "not-vaccinated",
-           view_states: %w[triaged_do_not_vaccinate unable_to_vaccinate]
+           view_states: %w[triaged_do_not_vaccinate unable_to_vaccinate unable_to_vaccinate_not_assessed unable_to_vaccinate_not_gillick_competent]
   end
 end
 %>

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -38,6 +38,7 @@
   ) %>
 <% end %>
 
+<% if @patient_session.able_to_vaccinate? %>
 <% if @consent_response.nil? %>
   <div class="nhsuk-card">
     <div class="nhsuk-card__content">
@@ -53,7 +54,7 @@
             link_errors: true %>
           <%= f.govuk_radio_button :route, "self_consent",
             label: { text: 'Yes, I am assessing Gillick competence' } %>
-          <%= f.govuk_radio_button :route, "not_provided",
+          <%= f.govuk_radio_button :route, "not_vaccinating",
             label: { text: 'No, I am not vaccinating' } %>
         <% end %>
 
@@ -123,8 +124,7 @@
       </dl>
     </div>
   </div>
-<% elsif @vaccination_record.nil? &&
-  !@patient_session.unable_to_vaccinate_not_gillick_competent? %>
+<% elsif @vaccination_record.nil? %>
   <div class="nhsuk-card">
     <div class="nhsuk-card__content">
       <%= form_with model: @draft_vaccination_record,
@@ -161,4 +161,5 @@
       <% end %>
     </div>
   </div>
+<% end %>
 <% end %>

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -42,6 +42,11 @@ en:
         absent_from_school: "%{full_name} was absent from school."
         absent_from_session: "%{full_name} was absent from the session."
         gave_consent: "Their %{who_responded} gave consent."
+    unable_to_vaccinate_not_assessed:
+      colour: red
+      text: Not vaccinated
+      banner_title: Not vaccinated
+      banner_explanation: No-one responded to our requests for consent.
     unable_to_vaccinate_not_gillick_competent:
       colour: red
       text: Not vaccinated

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe PatientSessionStateMachineConcern do
         expect(fsm).to be_unable_to_vaccinate_not_gillick_competent
       end
     end
+
+    describe "#do_vaccination" do
+      it "transitions to unable_to_vaccinate_not_assessed when consent_response is nil" do
+        allow(fsm).to receive(:consent_response).and_return(nil)
+
+        fsm.do_vaccination
+        expect(fsm).to be_unable_to_vaccinate_not_assessed
+      end
+    end
   end
 
   context "in consent_given_triage_not_needed state" do


### PR DESCRIPTION
Add the controller action that triggers the state transition, and hide the vaccination CTAs unless the user is able to be vaccinated.

### Ticking the "No" radio

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/0cda0131-879b-4fff-bfda-c1a11e1c6313)

### Record saved, now showing up in a different tab

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/2e051cfe-8597-468c-9ad6-ea25b046e092)

### Vaccination show page

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/8342448a-8800-4153-a226-7314d22ab6b8)

