### PR TITLE
Make banner and periods spacing consistent

### DIFF
--- a/app/components/app_banner_component.html.erb
+++ b/app/components/app_banner_component.html.erb
@@ -1,9 +1,9 @@
 <div class="app-consent-banner app-consent-banner--<%= colour %> nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-6">
-  <span class="nhsuk-heading-m nhsuk-u-margin-bottom-2">
+  <span class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
     <%= title %>
   </span>
   <% if explanation.present? %>
-    <p class="nhsuk-u-margin-top-2">
+    <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
       <%= explanation %>
     </p>
   <% end %>

--- a/app/components/app_status_banner_component.html.erb
+++ b/app/components/app_status_banner_component.html.erb
@@ -1,6 +1,6 @@
 <% if state.in? %[consent_given_triage_needed triaged_kept_in_triage] %>
   <%= render AppBannerComponent.new(title:, colour:) do %>
-    <ul class="nhsuk-list nhsuk-u-margin-bottom-2">
+    <ul class="nhsuk-list nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
       <% consent_response.reasons_triage_needed.map do |reason| %>
         <li><%= reason %></li>
       <% end %>

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -15,7 +15,7 @@ en:
     consent_refused:
       colour: orange
       text: Check refusal
-      banner_title: Their %{who_responded} has refused to give consent.
+      banner_title: Their %{who_responded} has refused to give consent
     triaged_do_not_vaccinate:
       colour: red
       text: Do not vaccinate
@@ -35,13 +35,13 @@ en:
       text: Unable to vaccinate
       banner_title: Could not vaccinate
       banner_explanation:
-        refused: "%{full_name} refused it"
-        now_well: "%{full_name} was not well enough"
-        contraindications: "%{full_name} had contraindications"
-        already_had: "%{full_name} has already had the vaccine"
-        absent_from_school: "%{full_name} was absent from school"
-        absent_from_session: "%{full_name} was absent from the session"
-        gave_consent: "Their %{who_responded} gave consent"
+        refused: "%{full_name} refused it."
+        now_well: "%{full_name} was not well enough."
+        contraindications: "%{full_name} had contraindications."
+        already_had: "%{full_name} has already had the vaccine."
+        absent_from_school: "%{full_name} was absent from school."
+        absent_from_session: "%{full_name} was absent from the session."
+        gave_consent: "Their %{who_responded} gave consent."
     unable_to_vaccinate_not_gillick_competent:
       colour: red
       text: Not vaccinated
@@ -51,4 +51,4 @@ en:
       colour: green
       text: Vaccinated
       banner_title: Vaccinated
-      banner_explanation: Their %{who_responded} gave consent
+      banner_explanation: Their %{who_responded} gave consent.

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     let(:patient_session) { create :patient_session, :consent_refused }
 
     it { should have_css(".app-consent-banner--orange") }
-    it { should have_text("Their mum has refused to give consent.") }
+    it { should have_text("Their mum has refused to give consent") }
   end
 
   context "state is triaged_do_not_vaccinate" do


### PR DESCRIPTION
Also make the periods consistent in explanations.

### Screenshots

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/ef71d02d-08ff-4a09-9ef0-efbd58952c96)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/3319b130-299c-4e38-b8c8-eb3a5b8cbcde)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/7ffe32dd-083b-43eb-84ce-3187310f6462)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/551f4f38-2627-4ea0-9063-a6b6ea6749cc)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/77ddca06-1a51-46d9-9192-021ead786195)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/d93b1646-95c9-4b25-9e25-bd3798dce49b)

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/d3fc6385-c18f-429b-857c-84fc83ea195d)

