### PR TITLE
Fix vaccination validation

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -2,12 +2,12 @@ class VaccinationsController < ApplicationController
   before_action :set_session
   before_action :set_patient, except: %i[index record_template]
   before_action :set_patient_sessions, only: %i[index record_template]
-  before_action :set_patient_session, only: %i[consent record show]
+  before_action :set_patient_session, only: %i[consent create record show]
   before_action :set_draft_vaccination_record,
                 only: %i[show confirm edit_reason record create update]
 
   before_action :set_vaccination_record, only: %i[show confirm record]
-  before_action :set_consent_response, only: %i[show confirm]
+  before_action :set_consent_response, only: %i[create show confirm]
   before_action :set_triage, only: %i[show confirm]
   before_action :set_draft_consent_response, only: %i[show consent]
   before_action :set_todays_batch_id, only: :create

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -143,9 +143,8 @@ class VaccinationsController < ApplicationController
   private
 
   def vaccination_record_params
-    p = params.require(:vaccination_record)
-    p[:site] = p[:site].to_i if p[:site].present?
-    p.permit(:administered, :site, :reason, :batch_id)
+    params.require(:vaccination_record)
+      .permit(:administered, :site, :reason, :batch_id)
   end
 
   def vaccination_record_administered_params

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -1,10 +1,4 @@
 module VaccinationsHelper
-  def vaccination_site_options
-    VaccinationRecord.sites.map do |k, id|
-      OpenStruct.new(id:, name: k.humanize)
-    end
-  end
-
   def vaccination_date(datetime)
     date = datetime.to_date
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -49,6 +49,12 @@ class VaccinationRecord < ApplicationRecord
               in: sites.keys,
             },
             if: -> { administered }
+  validates :reason,
+            inclusion: {
+              in: reasons.keys,
+            },
+            on: :edit_reason,
+            if: -> { !administered }
 
   def vaccine_name
     patient_session.session.campaign.vaccines.first.type
@@ -56,5 +62,9 @@ class VaccinationRecord < ApplicationRecord
 
   def location_name
     patient_session.session.location&.name
+  end
+
+  def not_administered?
+    !administered?
   end
 end

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -142,10 +142,9 @@
             label: { text: 'Yes, they got the HPV vaccine' },
             link_errors: true do %>
             <%= f.govuk_collection_radio_buttons :site,
-              vaccination_site_options,
-              :id,
-              :name,
-              :description,
+              VaccinationRecord.sites.keys,
+              :to_s,
+              :humanize,
               inline: true,
               legend: {
                 text: 'Where did they get it?',


### PR DESCRIPTION
Fixes a couple bugs on vaccinations page:

## Site selection

If a vaccination site is selected (Left arm, etc), this choice isn't persisted if you come back to the vaccination page without completing the vaccination recording journey. This rarely happens, but when it does is noticeable because the Administered / Not administered option is retained.

This fix also simplifies some code around processing the site params.

## Vaccination validation

When a user clicks "Continue" without selecting "Yes, they got the vaccine" or "No, they did not get it" this was resulting in a server error. This now returns with the correct validation error.

<img width="632" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/860305bd-0098-41f1-9b1c-20313c977ff8">


## Reason vaccine not administered

No validation was happening for the reason why a vaccine wasn't being administered. This is now fixed.

<img width="815" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/16325b2c-138d-444a-81c4-12484be61224">
