### PR TITLE
Allow triaging during consent journey

### DIFF
--- a/app/views/consent_responses/edit_confirm.html.erb
+++ b/app/views/consent_responses/edit_confirm.html.erb
@@ -82,6 +82,28 @@
   </div>
 <% end %>
 
+<% if @draft_triage.status.present? %>
+  <div class="nhsuk-card">
+    <div class="nhsuk-card__content">
+      <h2 class="nhsuk-card__heading nhsuk-heading-m">
+        Triage
+      </h2>
+
+      <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Triage notes" }
+          row.with_value { @draft_triage.notes }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Status" }
+          row.with_value { @draft_triage.status.humanize }
+        end
+      end %>
+    </div>
+  </div>
+<% end %>
+
 <%= govuk_button_to "Confirm",
   record_session_patient_consent_responses_path(@session, @patient),
   method: :put %>

--- a/app/views/consent_responses/edit_questions.html.erb
+++ b/app/views/consent_responses/edit_questions.html.erb
@@ -24,5 +24,23 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit "Continue" %>
+  <h2 class="nhsuk-card__heading nhsuk-heading-m nhsuk-u-margin-top-8">
+    Triage
+  </h2>
+
+  <%= f.fields_for @draft_triage do |ff| %>
+
+    <% content_for(:before_content) { ff.govuk_error_summary } %>
+
+    <%= ff.govuk_text_area :notes, label: { text: 'Triage notes' }, rows: 5 %>
+    <%= ff.govuk_collection_radio_buttons :status,
+                                         triage_form_status_options,
+                                         :first,
+                                         :second,
+                                         legend: { text: 'Triage status' } %>
+  <% end %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
 <% end %>

--- a/tests/consent.spec.ts
+++ b/tests/consent.spec.ts
@@ -36,6 +36,7 @@ test("Records consent", async ({ page }) => {
   await then_i_see_the_health_questions_page();
 
   await when_i_answer_the_health_questions();
+  await and_i_triage_the_patient();
   await and_i_click_continue();
   await then_i_see_the_check_answers_page();
 
@@ -97,6 +98,11 @@ async function when_i_answer_the_health_questions() {
   await p.click(radio(1));
   await p.click(radio(2));
   await p.click(radio(3));
+}
+
+async function and_i_triage_the_patient() {
+  await p.fill('[name="consent_response[triage][notes]"]', "Some notes");
+  await p.getByRole("radio", { name: "Ready to vaccinate" }).click();
 }
 
 async function and_i_click_continue() {

--- a/tests/gillick.spec.ts
+++ b/tests/gillick.spec.ts
@@ -30,6 +30,7 @@ test("Records gillick consent", async ({ page }) => {
   await then_i_see_the_health_questions_page();
 
   await when_i_answer_the_health_questions();
+  await and_i_triage_the_patient();
   await and_i_click_continue();
   await then_i_see_the_check_answers_page();
   await and_it_contains_gillick_assessment_details();
@@ -153,4 +154,9 @@ async function when_i_click_no_they_are_not_gillick_competent() {
 
 async function then_i_see_the_vaccination_show_page_for_the_second_patient() {
   await expect(p.locator("h1")).toContainText("Mariano Kuhic");
+}
+
+async function and_i_triage_the_patient() {
+  await p.fill('[name="consent_response[triage][notes]"]', "Some notes");
+  await p.getByRole("radio", { name: "Ready to vaccinate" }).click();
 }


### PR DESCRIPTION
This adds a triage form and fields that can be filled in to immediately add a triage to the patient. Once consent is granted, .do_consent and .do_triage are run sequentially to bring the patient_session to the vaccinate/do not vaccinate state.

### New triage form

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/042d1a81-d638-4aa2-8889-00fab4b7291a)

### Triage details on confirm page

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/c46c8879-e038-4789-9541-ae42f479c7ef)

### Patient is immediately ready to vaccinate

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/dd14bd05-323c-439d-a44f-921590e2e825)
