### PR TITLE
Tab counts in triage area

### DIFF
--- a/app/views/triage/_patients_with_dob.html.erb
+++ b/app/views/triage/_patients_with_dob.html.erb
@@ -1,25 +1,22 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <%
-    view_patient_sessions = @patient_sessions.select { |ps| ps.state.in? view_states }
-    if view_patient_sessions.any?
-    %>
-    <table id="patients" class="nhsuk-table">
-      <thead class="nhsuk-table__head">
-        <tr class="nhsuk-table__row">
-          <th class="nhsuk-table__header">Name</th>
-          <th class="nhsuk-table__header">Date of birth</th>
-          <th class="nhsuk-table__header">Action</th>
-        </tr>
-      </thead>
-      <tbody class="nhsuk-table__body">
-        <% view_patient_sessions.each do |patient_session| %>
-          <%= render "patient_row", middle_column: :dob, patient_session: %>
-        <% end %>
-      </tbody>
-    </table>
-<% else %>
-    <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
-<% end %>
+    <% if patient_sessions.any? %>
+      <table id="patients" class="nhsuk-table">
+        <thead class="nhsuk-table__head">
+          <tr class="nhsuk-table__row">
+            <th class="nhsuk-table__header">Name</th>
+            <th class="nhsuk-table__header">Date of birth</th>
+            <th class="nhsuk-table__header">Action</th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+          <% patient_sessions.each do |patient_session| %>
+            <%= render "patient_row", middle_column: :dob, patient_session: %>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
+    <% end %>
   </div>
 </div>

--- a/app/views/triage/_patients_with_triage_reasons.html.erb
+++ b/app/views/triage/_patients_with_triage_reasons.html.erb
@@ -1,25 +1,22 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
-    <%
-    view_patient_sessions = @patient_sessions.select { |ps| ps.state.in? view_states }
-    if view_patient_sessions.any?
-    %>
-    <table id="patients" class="nhsuk-table">
-      <thead class="nhsuk-table__head">
-        <tr class="nhsuk-table__row">
-          <th class="nhsuk-table__header">Name</th>
-          <th class="nhsuk-table__header">Triage reason</th>
-          <th class="nhsuk-table__header">Action</th>
-        </tr>
-      </thead>
-      <tbody class="nhsuk-table__body">
-        <% view_patient_sessions.each do |patient_session| %>
-          <%= render "patient_row", middle_column: :triage_reasons, patient_session: %>
-        <% end %>
-      </tbody>
-    </table>
-<% else %>
-    <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
-<% end %>
+    <% if patient_sessions.any? %>
+      <table id="patients" class="nhsuk-table">
+        <thead class="nhsuk-table__head">
+          <tr class="nhsuk-table__row">
+            <th class="nhsuk-table__header">Name</th>
+            <th class="nhsuk-table__header">Triage reason</th>
+            <th class="nhsuk-table__header">Action</th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+          <% patient_sessions.each do |patient_session| %>
+            <%= render "patient_row", middle_column: :triage_reasons, patient_session: %>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
+    <% end %>
   </div>
 </div>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -14,16 +14,16 @@
 
 <%=
 govuk_tabs title: "Patient triage", classes: 'nhsuk-tabs' do |c|
-  c.with_tab(label: "Needs triage", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(label: "Needs triage (#{ @partitioned_patient_sessions[:needs_triage].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_triage_reasons", patient_sessions: @partitioned_patient_sessions[:needs_triage]
   end
-  c.with_tab(label: "Triage complete", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(label: "Triage complete (#{ @partitioned_patient_sessions[:triage_complete].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_triage_reasons", patient_sessions: @partitioned_patient_sessions[:triage_complete]
   end
-  c.with_tab(label: "Get consent", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(label: "Get consent (#{ @partitioned_patient_sessions[:get_consent].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_dob", patient_sessions: @partitioned_patient_sessions[:get_consent]
   end
-  c.with_tab(label: "No triage needed", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(label: "No triage needed (#{ @partitioned_patient_sessions[:no_triage_needed].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_dob", patient_sessions: @partitioned_patient_sessions[:no_triage_needed]
   end
 end

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -15,18 +15,16 @@
 <%=
 govuk_tabs title: "Patient triage", classes: 'nhsuk-tabs' do |c|
   c.with_tab(label: "Needs triage", classes: 'nhsuk-tabs__panel') do
-    render "patients_with_triage_reasons", view_states: %w[consent_given_triage_needed triaged_kept_in_triage]
+    render "patients_with_triage_reasons", patient_sessions: @partitioned_patient_sessions[:needs_triage]
   end
   c.with_tab(label: "Triage complete", classes: 'nhsuk-tabs__panel') do
-    render "patients_with_triage_reasons",
-           view_states: %w[triaged_ready_to_vaccinate triaged_do_not_vaccinate]
+    render "patients_with_triage_reasons", patient_sessions: @partitioned_patient_sessions[:triage_complete]
   end
   c.with_tab(label: "Get consent", classes: 'nhsuk-tabs__panel') do
-    render "patients_with_dob", view_states: %w[added_to_session]
+    render "patients_with_dob", patient_sessions: @partitioned_patient_sessions[:get_consent]
   end
   c.with_tab(label: "No triage needed", classes: 'nhsuk-tabs__panel') do
-    render "patients_with_dob",
-           view_states: %w[consent_refused consent_given_triage_not_needed vaccinated unable_to_vaccinate]
+    render "patients_with_dob", patient_sessions: @partitioned_patient_sessions[:no_triage_needed]
   end
 end
 %>

--- a/tests/consent.spec.ts
+++ b/tests/consent.spec.ts
@@ -52,7 +52,7 @@ async function when_i_go_to_the_triage_page() {
 }
 
 async function and_i_click_the_consent_tab() {
-  await p.getByRole("tab", { name: "Get consent", exact: true }).click();
+  await p.getByRole("tab", { name: "Get consent (2)", exact: true }).click();
 }
 
 async function then_i_see_the_patient_that_needs_consent() {

--- a/tests/example_data.ts
+++ b/tests/example_data.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 
 export const patientExpectations = {
   "Blaine DuBuque": {
-    tab: "Needs triage",
+    tab: "Needs triage (2)",
     action: "Triage",
     actionColour: "blue",
     bannerTitle: "Triage needed",
@@ -14,41 +14,41 @@ export const patientExpectations = {
     parentRelationship: "Mother",
   },
   "Caridad Sipes": {
-    tab: "Needs triage",
+    tab: "Needs triage (2)",
     action: "Triage started",
     actionColour: "aqua-green",
     bannerTitle: "Triage started",
     triageReasons: ["Notes need triage"],
   },
   "Jessika Lindgren": {
-    tab: "Triage complete",
+    tab: "Triage complete (2)",
     action: "Vaccinate",
     actionColour: "purple",
   },
   "Kristal Schumm": {
-    tab: "Triage complete",
+    tab: "Triage complete (2)",
     action: "Do not vaccinate",
     actionColour: "red",
     bannerTitle: "Do not vaccinate",
   },
   "Alexandra Sipes": {
-    tab: "Get consent",
+    tab: "Get consent (2)",
     action: "Get consent",
     actionColour: "yellow",
     bannerTitle: "No-one responded to our requests for consent",
   },
   "Ernie Funk": {
-    tab: "No triage needed",
+    tab: "No triage needed (3)",
     action: /.*/,
     actionColour: "purple",
   },
   "Fae Skiles": {
-    tab: "No triage needed",
+    tab: "No triage needed (3)",
     action: "Check refusal",
     actionColour: "orange",
   },
   "Man Swaniawski": {
-    tab: "No triage needed",
+    tab: "No triage needed (3)",
     action: "Vaccinate",
     actionColour: "purple",
   },

--- a/tests/triaging_patients.spec.ts
+++ b/tests/triaging_patients.spec.ts
@@ -19,14 +19,14 @@ test("Triaging patients", async ({ page }) => {
   await when_i_go_to_the_triage_page_for_the_first_session();
 
   // Triage - start triage but without outcome
-  await when_i_click_on_the_tab("Needs triage");
+  await when_i_click_on_the_tab("Needs triage (2)");
   await when_i_click_on_the_patient("Caridad Sipes");
   await when_i_enter_the_note("Unable to reach mother");
   await when_i_click_on_the_option("Keep in triage");
   await when_i_click_on_the_submit_button();
-  await when_i_click_on_the_tab("Needs triage");
+  await when_i_click_on_the_tab("Needs triage (2)");
   await then_i_should_see_a_row_for_the_patient("Caridad Sipes", {
-    tab: "Needs triage",
+    tab: "Needs triage (2)",
     action: "Triage started",
   });
 
@@ -35,9 +35,9 @@ test("Triaging patients", async ({ page }) => {
   await when_i_enter_the_note("Reached mother, should be able to proceed");
   await when_i_click_on_the_option("Ready to vaccinate");
   await when_i_click_on_the_submit_button();
-  await when_i_click_on_the_tab("Triage complete");
+  await when_i_click_on_the_tab("Triage complete (3)");
   await then_i_should_see_a_row_for_the_patient("Caridad Sipes", {
-    tab: "Triage complete",
+    tab: "Triage complete (3)",
     action: "Vaccinate",
   });
 });
@@ -57,7 +57,7 @@ async function when_i_click_on_the_submit_button() {
 
 async function then_i_should_see_a_row_for_the_patient(name, attributes) {
   const patient = { ...patientExpectations[name], ...attributes };
-  const id = patient.tab.toLowerCase().replace(/ /g, "-");
+  const id = patient.tab.toLowerCase().replace(/ /g, "-").replace(/[()]/g, "");
   const row = p.locator(`#${id} tr`, { hasText: name });
 
   await expect(row).toBeVisible();

--- a/tests/viewing_patients_in_triage.spec.ts
+++ b/tests/viewing_patients_in_triage.spec.ts
@@ -20,7 +20,7 @@ test("Viewing patients", async ({ page }) => {
   await when_i_go_to_the_triage_page_for_the_first_session();
   await then_i_should_see_the_triage_index_page();
   await then_i_should_see_the_correct_breadcrumbs();
-  await then_i_should_be_on_the_tab("Needs triage");
+  await then_i_should_be_on_the_tab("Needs triage (2)");
 
   for (let name in patientExpectations) {
     if (!patientExpectations[name].tab) continue;
@@ -75,7 +75,7 @@ export async function then_i_should_see_a_triage_row_for_the_patient(
   attributes = {},
 ) {
   const patient = { ...patientExpectations[name], ...attributes };
-  const id = patient.tab.toLowerCase().replace(/ /g, "-");
+  const id = patient.tab.toLowerCase().replace(/ /g, "-").replace(/[()]/g, "");
   const row = p.locator(`#${id} tr`, { hasText: name });
 
   if (patient.triageReasons) {


### PR DESCRIPTION
## What it looks like

<img width="992" alt="image" src="https://github.com/nhsuk/record-childrens-vaccinations/assets/23801/15557912-fc89-426c-b9af-5dee2072cc0e">

## Comments for reviewers

This PR moves the tab partitioning logic out of the view and into the controller.
It's really frustrating having to specify the tab counts in the Playwright specs.
It's doubly frustrating that the tab IDs have the counts in them, as they're derived from the tab label.