### PR TITLE
Allow triage when records in consent_refused state

### DIFF
--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -38,15 +38,30 @@ module PatientSessionStateMachineConcern
       end
 
       event :do_triage do
-        transitions from: %i[consent_given_triage_needed consent_given_triage_not_needed triaged_kept_in_triage],
+        transitions from: %i[
+                      consent_given_triage_needed
+                      consent_given_triage_not_needed
+                      triaged_kept_in_triage
+                      consent_refused
+                    ],
                     to: :triaged_ready_to_vaccinate,
                     if: :triage_ready_to_vaccinate?
 
-        transitions from: %i[consent_given_triage_needed consent_given_triage_not_needed triaged_kept_in_triage],
+        transitions from: %i[
+                      consent_given_triage_needed
+                      consent_given_triage_not_needed
+                      triaged_kept_in_triage
+                      consent_refused
+                    ],
                     to: :triaged_do_not_vaccinate,
                     if: :triage_do_not_vaccinate?
 
-        transitions from: %i[consent_given_triage_needed consent_given_triage_not_needed triaged_kept_in_triage],
+        transitions from: %i[
+                      consent_given_triage_needed
+                      consent_given_triage_not_needed
+                      triaged_kept_in_triage
+                      consent_refused
+                    ],
                     to: :triaged_kept_in_triage,
                     if: :triage_keep_in_triage?
       end


### PR DESCRIPTION
When consent is refused nurses will still do triage and could transition to other states.

I think this is the fix, if so I will add tests.