### PR TITLE
Add sentry integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "okcomputer"
 gem "pg", "~> 1.5"
 gem "propshaft"
 gem "puma", "~> 6.3"
+gem "sentry-rails"
+gem "sentry-ruby"
 gem "silencer", require: false
 gem "stimulus-rails"
 gem "turbo-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,6 +456,11 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sentry-rails (5.10.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.10.0)
+    sentry-ruby (5.10.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     silencer (2.0.0)
     solargraph (0.49.0)
       backport (~> 1.2)
@@ -563,6 +568,8 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  sentry-rails
+  sentry-ruby
   silencer
   solargraph
   solargraph-rails

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,12 @@
+require 'active_support/parameter_filter'
+
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  config.traces_sample_rate = 1.0
+
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda do |event, _hint|
+    filter.filter(event.to_hash)
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,8 +5,30 @@ Sentry.init do |config|
 
   config.traces_sample_rate = 1.0
 
-  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  rails_filter_parameters =
+    Rails.application.config.filter_parameters.map(&:to_s)
+
+  sensitive_env_vars = ENV.select do |key, _v|
+    rails_filter_parameters.any? do |parameter|
+      key.downcase.include?(parameter)
+    end
+  end
+
+  sensitive_values_pattern = Regexp.union(sensitive_env_vars.values)
+
+  sensitive_value_filter = ->(key, value) do
+    key_is_relevant = %i[value title].include?(key)
+
+    if key_is_relevant && sensitive_values_pattern.match?(value)
+      value.gsub!(sensitive_values_pattern, "[FILTERED]")
+    end
+  end
+
+  combined_filter = ActiveSupport::ParameterFilter.new(
+    Rails.application.config.filter_parameters + [sensitive_value_filter],
+  )
+
   config.before_send = lambda do |event, _hint|
-    filter.filter(event.to_hash)
+    combined_filter.filter(event.to_hash)
   end
 end


### PR DESCRIPTION
Generic Sentry integration added. Relies on `SENTRY_DSN` being set in the deployed environment.

This change has been tested, however we don't have a team account on Sentry. At the moment I'm just using a DSN for the organisation "Good Machine" setup on my account; to invite other members to it will require a team, business or open source account, so far as I can see.