### PR TITLE
Display current short git sha at /sha

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module ManageVaccinations
     config.exceptions_app = routes
 
     config.time_zone = "London"
+
+    config.commit_sha = `git rev-parse --short HEAD`.strip
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "/dashboard", to: "dashboard#index"
 
   get "/ping" => proc { [200, {}, ["PONG"]] }
+  get "/sha" => proc { [200, {}, [Rails.application.config.commit_sha]] }
 
   get "/reset", to: "dev#reset" if Rails.env.development? || Rails.env.test?
 


### PR DESCRIPTION
Adds a new config variable and exposes it using a route.

```
$ curl http://localhost:4000/sha 
b9f1d67
```