### PR TITLE
Fix Ruby formatter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@prettier/plugin-ruby"]
+}

--- a/app/avo/resources/vaccination_record_resource.rb
+++ b/app/avo/resources/vaccination_record_resource.rb
@@ -10,7 +10,9 @@ class VaccinationRecordResource < Avo::BaseResource
   field :patient_session, as: :belongs_to
   field :administered, as: :boolean
   field :delivery_site, as: :select, enum: ::VaccinationRecord.delivery_sites
-  field :delivery_method, as: :select, enum: ::VaccinationRecord.delivery_methods
+  field :delivery_method,
+        as: :select,
+        enum: ::VaccinationRecord.delivery_methods
   field :recorded_at, as: :date
   # add fields here
 end

--- a/app/components/app_status_banner_component.rb
+++ b/app/components/app_status_banner_component.rb
@@ -6,28 +6,34 @@ class AppStatusBannerComponent < ViewComponent::Base
   end
 
   def title
-    I18n.t("patient_session_statuses.#{state}.banner_title",
-           full_name:,
-           who_responded: who_responded&.downcase)
+    I18n.t(
+      "patient_session_statuses.#{state}.banner_title",
+      full_name:,
+      who_responded: who_responded&.downcase
+    )
   end
 
   def explanation
     if state == "unable_to_vaccinate"
-      reason_for_refusal = I18n.t(
-        "patient_session_statuses.#{state}.banner_explanation.#{vaccination_record.reason}",
-        full_name:,
-      )
-      gave_consent = I18n.t(
-        "patient_session_statuses.#{state}.banner_explanation.gave_consent",
-        who_responded: who_responded.downcase,
-      )
+      reason_for_refusal =
+        I18n.t(
+          "patient_session_statuses.#{state}.banner_explanation.#{vaccination_record.reason}",
+          full_name:
+        )
+      gave_consent =
+        I18n.t(
+          "patient_session_statuses.#{state}.banner_explanation.gave_consent",
+          who_responded: who_responded.downcase
+        )
 
       "#{reason_for_refusal}\n<br />\n#{gave_consent}".html_safe
     else
-      I18n.t("patient_session_statuses.#{state}.banner_explanation",
-             default: "",
-             full_name:,
-             who_responded: who_responded&.downcase)
+      I18n.t(
+        "patient_session_statuses.#{state}.banner_explanation",
+        default: "",
+        full_name:,
+        who_responded: who_responded&.downcase
+      )
     end
   end
 

--- a/app/controllers/consent_responses_controller.rb
+++ b/app/controllers/consent_responses_controller.rb
@@ -12,16 +12,14 @@ class ConsentResponsesController < ApplicationController
   end
 
   def create
-    health_questions = ConsentResponse::HEALTH_QUESTIONS
-            .fetch(:hpv)
-            .map { |question| { question: } }
+    health_questions =
+      ConsentResponse::HEALTH_QUESTIONS
+        .fetch(:hpv)
+        .map { |question| { question: } }
 
     if consent_response_who_params.present?
       @draft_consent_response.assign_attributes(
-        consent_response_who_params.merge(
-          route: "phone",
-          health_questions:
-        )
+        consent_response_who_params.merge(route: "phone", health_questions:)
       )
       if @draft_consent_response.save(context: :edit_who)
         redirect_to action: :edit_consent
@@ -31,10 +29,7 @@ class ConsentResponsesController < ApplicationController
     else
       # If the params are missing, assume this is the Gillick competence route.
       # This feels like it could be more explicit.
-      @draft_consent_response.update!(
-        route: "self_consent",
-        health_questions:
-      )
+      @draft_consent_response.update!(route: "self_consent", health_questions:)
 
       redirect_to action: :edit_gillick
     end
@@ -101,11 +96,12 @@ class ConsentResponsesController < ApplicationController
         end
 
         redirect_to session_patient_vaccinations_path(@session, @patient),
-          flash: {
-            success: {
-              body: "Gillick assessment saved for #{@patient.full_name}",
-            },
-          }
+                    flash: {
+                      success: {
+                        body:
+                          "Gillick assessment saved for #{@patient.full_name}"
+                      }
+                    }
       end
     else
       render :edit_gillick
@@ -146,19 +142,20 @@ class ConsentResponsesController < ApplicationController
       redirect_to session_patient_vaccinations_path(@session, @patient),
                   flash: {
                     success: {
-                      body: "Gillick assessment saved for #{@patient.full_name}",
-                    },
+                      body: "Gillick assessment saved for #{@patient.full_name}"
+                    }
                   }
     else
       redirect_to triage_session_path(@session),
                   flash: {
                     success: {
                       title: "Consent saved for #{@patient.full_name}",
-                      body: ActionController::Base.helpers.link_to(
-                        "View child record",
-                        session_patient_triage_path(@session, @patient)
-                      ),
-                    },
+                      body:
+                        ActionController::Base.helpers.link_to(
+                          "View child record",
+                          session_patient_triage_path(@session, @patient)
+                        )
+                    }
                   }
     end
   end
@@ -178,19 +175,22 @@ class ConsentResponsesController < ApplicationController
   end
 
   def set_draft_consent_response
-    @draft_consent_response = @patient
-      .consent_responses
-      .find_or_initialize_by(recorded_at: nil, campaign: @session.campaign)
+    @draft_consent_response =
+      @patient.consent_responses.find_or_initialize_by(
+        recorded_at: nil,
+        campaign: @session.campaign
+      )
   end
 
   def set_draft_triage
-    @draft_triage = Triage.find_or_initialize_by(patient_session: @patient_session)
+    @draft_triage =
+      Triage.find_or_initialize_by(patient_session: @patient_session)
   end
 
   def patient_session_gillick_params
     params.fetch(:patient_session, {}).permit(
       :gillick_competent,
-      :gillick_competence_notes,
+      :gillick_competence_notes
     )
   end
 
@@ -199,35 +199,31 @@ class ConsentResponsesController < ApplicationController
       :parent_name,
       :parent_phone,
       :parent_relationship,
-      :parent_relationship_other,
+      :parent_relationship_other
     )
   end
 
   def consent_response_agree_params
-    params.fetch(:consent_response, {}).permit(
-      :consent,
-    )
+    params.fetch(:consent_response, {}).permit(:consent)
   end
 
   def consent_response_reason_params
     params.fetch(:consent_response, {}).permit(
       :reason_for_refusal,
-      :reason_for_refusal_other,
+      :reason_for_refusal_other
     )
   end
 
   def consent_response_health_questions_params
     params.fetch(:consent_response, {}).permit(
-      question_0: [:notes, :response],
-      question_1: [:notes, :response],
-      question_2: [:notes, :response],
-      question_3: [:notes, :response],
+      question_0: %i[notes response],
+      question_1: %i[notes response],
+      question_2: %i[notes response],
+      question_3: %i[notes response]
     )
   end
 
   def consent_response_triage_params
-    params.fetch(:consent_response, {}).permit(
-      triage: [:notes, :status],
-    )
+    params.fetch(:consent_response, {}).permit(triage: %i[notes status])
   end
 end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -19,12 +19,20 @@ class TriageController < ApplicationController
       needs_triage: %w[consent_given_triage_needed triaged_kept_in_triage],
       triage_complete: %w[triaged_ready_to_vaccinate triaged_do_not_vaccinate],
       get_consent: %w[added_to_session],
-      no_triage_needed: %w[consent_refused consent_given_triage_not_needed vaccinated unable_to_vaccinate],
+      no_triage_needed: %w[
+        consent_refused
+        consent_given_triage_not_needed
+        vaccinated
+        unable_to_vaccinate
+      ]
     }
 
-    @partitioned_patient_sessions = patient_sessions.group_by do |patient_session|
-      tabs_to_states.find { |_, states| patient_session.state.in? states }&.first
-    end
+    @partitioned_patient_sessions =
+      patient_sessions.group_by do |patient_session|
+        tabs_to_states
+          .find { |_, states| patient_session.state.in? states }
+          &.first
+      end
 
     # ensure all tabs are present
     tabs_to_states.each do |tab, _states|

--- a/app/controllers/vaccinations/batches_controller.rb
+++ b/app/controllers/vaccinations/batches_controller.rb
@@ -45,8 +45,9 @@ class Vaccinations::BatchesController < ApplicationController
 
   def update_default_batch_for_today
     if params.dig(:vaccination_record, :todays_batch).present? &&
-       vaccination_record_batch_params[:batch_id].in?(params[:vaccination_record][:todays_batch])
-
+         vaccination_record_batch_params[:batch_id].in?(
+           params[:vaccination_record][:todays_batch]
+         )
       session[:todays_batch_id] = vaccination_record_batch_params[:batch_id]
       session[:todays_batch_date] = Time.zone.now.to_date
     elsif session.key?(:todays_batch_date) != Time.zone.now.to_date.to_s

--- a/app/controllers/vaccinations/delivery_site_controller.rb
+++ b/app/controllers/vaccinations/delivery_site_controller.rb
@@ -5,12 +5,20 @@ class Vaccinations::DeliverySiteController < ApplicationController
   before_action :set_draft_vaccination_record, only: %i[edit update]
 
   def update
-    @draft_vaccination_record.assign_attributes(vaccination_record_delivery_params)
+    @draft_vaccination_record.assign_attributes(
+      vaccination_record_delivery_params
+    )
     if @draft_vaccination_record.save(context: :edit_delivery)
       if @draft_vaccination_record.batch_id.present?
-        redirect_to confirm_session_patient_vaccinations_path(@session, @patient)
+        redirect_to confirm_session_patient_vaccinations_path(
+                      @session,
+                      @patient
+                    )
       else
-        redirect_to edit_session_patient_vaccinations_batch_path(@session, @patient)
+        redirect_to edit_session_patient_vaccinations_batch_path(
+                      @session,
+                      @patient
+                    )
       end
     else
       render action: :edit

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -2,7 +2,8 @@ class VaccinationsController < ApplicationController
   before_action :set_session
   before_action :set_patient, except: %i[index record_template]
   before_action :set_patient_sessions, only: %i[index record_template]
-  before_action :set_patient_session, only: %i[confirm consent create record show update]
+  before_action :set_patient_session,
+                only: %i[confirm consent create record show update]
   before_action :set_draft_vaccination_record,
                 only: %i[show confirm edit_reason record create update]
 
@@ -16,16 +17,29 @@ class VaccinationsController < ApplicationController
 
   def index
     tabs_to_states = {
-      action_needed: %w[consent_given_triage_needed triaged_kept_in_triage triaged_ready_to_vaccinate added_to_session
-consent_refused consent_given_triage_not_needed],
+      action_needed: %w[
+        consent_given_triage_needed
+        triaged_kept_in_triage
+        triaged_ready_to_vaccinate
+        added_to_session
+        consent_refused
+        consent_given_triage_not_needed
+      ],
       vaccinated: %w[vaccinated],
-      not_vaccinated: %w[triaged_do_not_vaccinate unable_to_vaccinate unable_to_vaccinate_not_assessed 
-unable_to_vaccinate_not_gillick_competent]
+      not_vaccinated: %w[
+        triaged_do_not_vaccinate
+        unable_to_vaccinate
+        unable_to_vaccinate_not_assessed
+        unable_to_vaccinate_not_gillick_competent
+      ]
     }
 
-    @partitioned_patient_sessions = @patient_sessions.group_by do |patient_session|
-      tabs_to_states.find { |_, states| patient_session.state.in? states }&.first
-    end
+    @partitioned_patient_sessions =
+      @patient_sessions.group_by do |patient_session|
+        tabs_to_states
+          .find { |_, states| patient_session.state.in? states }
+          &.first
+      end
 
     # ensure all tabs are present
     tabs_to_states.each do |tab, _states|
@@ -66,11 +80,12 @@ unable_to_vaccinate_not_gillick_competent]
                 flash: {
                   success: {
                     title: "Record saved for #{@patient.full_name}",
-                    body: ActionController::Base.helpers.link_to(
-                      "View child record",
-                      session_patient_vaccinations_path(@session, @patient)
-                    ),
-                  },
+                    body:
+                      ActionController::Base.helpers.link_to(
+                        "View child record",
+                        session_patient_vaccinations_path(@session, @patient)
+                      )
+                  }
                 }
   end
 
@@ -106,19 +121,29 @@ unable_to_vaccinate_not_gillick_competent]
 
   def create
     if @draft_vaccination_record.update(create_params)
-
       if @draft_vaccination_record.administered?
         if @draft_vaccination_record.delivery_site_other
-          redirect_to edit_session_patient_vaccinations_delivery_site_path(@session, @patient)
+          redirect_to edit_session_patient_vaccinations_delivery_site_path(
+                        @session,
+                        @patient
+                      )
         elsif @draft_vaccination_record.batch_id.present?
-          redirect_to confirm_session_patient_vaccinations_path(@session, @patient)
+          redirect_to confirm_session_patient_vaccinations_path(
+                        @session,
+                        @patient
+                      )
         else
-          redirect_to edit_session_patient_vaccinations_batch_path(@session, @patient)
+          redirect_to edit_session_patient_vaccinations_batch_path(
+                        @session,
+                        @patient
+                      )
         end
       else
-        redirect_to edit_reason_session_patient_vaccinations_path(@session, @patient)
+        redirect_to edit_reason_session_patient_vaccinations_path(
+                      @session,
+                      @patient
+                    )
       end
-
     else
       render :show
     end
@@ -138,36 +163,46 @@ unable_to_vaccinate_not_gillick_competent]
     when "not_vaccinating"
       @patient_session.do_vaccination!
       redirect_to vaccinations_session_path(@session),
-        flash: {
-          success: {
-            title: "Record saved for #{@patient.full_name}",
-            body: ActionController::Base.helpers.link_to(
-              "View child record",
-              session_patient_vaccinations_path(@session, @patient)
-            ),
-          },
-        }
+                  flash: {
+                    success: {
+                      title: "Record saved for #{@patient.full_name}",
+                      body:
+                        ActionController::Base.helpers.link_to(
+                          "View child record",
+                          session_patient_vaccinations_path(@session, @patient)
+                        )
+                    }
+                  }
     when "phone"
       redirect_to new_session_patient_consent_responses_path(@session, @patient)
     when "self_consent"
-      redirect_to assessing_gillick_session_patient_consent_responses_path(@session, @patient)
+      redirect_to assessing_gillick_session_patient_consent_responses_path(
+                    @session,
+                    @patient
+                  )
     end
   end
 
   private
 
   def vaccination_record_params
-    params.fetch(:vaccination_record, {})
-      .permit(:administered, :delivery_site, :delivery_method, :reason, :batch_id)
+    params.fetch(:vaccination_record, {}).permit(
+      :administered,
+      :delivery_site,
+      :delivery_method,
+      :reason,
+      :batch_id
+    )
   end
 
   def create_params
     if vaccination_record_params[:administered] == "true"
-      create_params = if delivery_site_param_other?
-                        vaccination_record_params_with_delivery_other
-                      else
-                        vaccination_record_params
-                      end
+      create_params =
+        if delivery_site_param_other?
+          vaccination_record_params_with_delivery_other
+        else
+          vaccination_record_params
+        end
       create_params.merge(batch_id: @todays_batch_id)
     else
       vaccination_record_params
@@ -175,19 +210,17 @@ unable_to_vaccinate_not_gillick_competent]
   end
 
   def vaccination_record_params_with_delivery_other
-    vaccination_record_params
-      .except(:delivery_site, :delivery_method)
-      .merge(delivery_site_other: "true")
+    vaccination_record_params.except(:delivery_site, :delivery_method).merge(
+      delivery_site_other: "true"
+    )
   end
 
   def vaccination_record_administered_params
-    params.fetch(:vaccination_record, {})
-      .permit(:administered, :delivery_site)
+    params.fetch(:vaccination_record, {}).permit(:administered, :delivery_site)
   end
 
   def vaccination_record_reason_params
-    params.fetch(:vaccination_record, {})
-      .permit(:reason)
+    params.fetch(:vaccination_record, {}).permit(:reason)
   end
 
   def consent_response_params
@@ -243,14 +276,13 @@ unable_to_vaccinate_not_gillick_competent]
   end
 
   def set_draft_consent_response
-    @draft_consent_response = @patient
-      .consent_responses
-      .find_or_initialize_by(recorded_at: nil)
+    @draft_consent_response =
+      @patient.consent_responses.find_or_initialize_by(recorded_at: nil)
   end
 
   def set_todays_batch_id
     if session.key?(:todays_batch_id) && session.key?(:todays_batch_date) &&
-       session[:todays_batch_date] == Time.zone.now.to_date.to_s
+         session[:todays_batch_date] == Time.zone.now.to_date.to_s
       @todays_batch_id = session[:todays_batch_id]
     end
   end

--- a/app/helpers/patient_session_helper.rb
+++ b/app/helpers/patient_session_helper.rb
@@ -3,56 +3,56 @@ module PatientSessionHelper
     added_to_session: {
       colour: "yellow",
       text: "Get consent",
-      banner_title: "No-one responded to our requests for consent",
+      banner_title: "No-one responded to our requests for consent"
     },
     consent_given_triage_needed: {
       colour: "blue",
       text: "Triage",
-      banner_title: "Triage needed",
+      banner_title: "Triage needed"
     },
     consent_given_triage_not_needed: {
       colour: "purple",
-      text: "Vaccinate",
+      text: "Vaccinate"
     },
     consent_refused: {
       colour: "orange",
       text: "Check refusal",
-      banner_title: "Their %{who_responded} has refused to give consent",
+      banner_title: "Their %{who_responded} has refused to give consent"
     },
     triaged_do_not_vaccinate: {
       colour: "red",
       text: "Do not vaccinate",
-      banner_title: "Do not vaccinate",
+      banner_title: "Do not vaccinate"
     },
     triaged_kept_in_triage: {
       colour: "aqua-green",
       text: "Triage started",
-      banner_title: "Triage started",
+      banner_title: "Triage started"
     },
     triaged_ready_to_vaccinate: {
       colour: "purple",
-      text: "Vaccinate",
+      text: "Vaccinate"
     },
     unable_to_vaccinate: {
       colour: "orange",
       text: "Unable to vaccinate",
-      banner_title: "Could not vaccinate",
+      banner_title: "Could not vaccinate"
     },
     unable_to_vaccinate_not_assessed: {
       colour: "red",
       text: "Not vaccinated",
-      banner_title: "Not vaccinated",
+      banner_title: "Not vaccinated"
     },
     unable_to_vaccinate_not_gillick_competent: {
       colour: "red",
       text: "Not vaccinated",
-      banner_title: "Not vaccinated",
+      banner_title: "Not vaccinated"
     },
     vaccinated: {
       colour: "green",
       text: "Vaccinated",
-      banner_title: "Vaccinated",
-    },
+      banner_title: "Vaccinated"
+    }
   }.with_indifferent_access.freeze
 
   def status_colour_for_state(state)

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -38,12 +38,17 @@ module VaccinationsHelper
 
   def vaccination_delivery_methods
     methods = VaccinationRecord.delivery_methods.keys
-    methods.map { |m| [m, VaccinationRecord.human_enum_name("delivery_methods", m)] }
+    methods.map do |m|
+      [m, VaccinationRecord.human_enum_name("delivery_methods", m)]
+    end
   end
 
   def vaccination_delivery_sites
-    sites = VaccinationRecord.delivery_sites.keys - vaccination_initial_delivery_sites
-    sites.map { |s| [s, VaccinationRecord.human_enum_name("delivery_sites", s)] }
+    sites =
+      VaccinationRecord.delivery_sites.keys - vaccination_initial_delivery_sites
+    sites.map do |s|
+      [s, VaccinationRecord.human_enum_name("delivery_sites", s)]
+    end
   end
 
   def in_tab_action_needed?(action, _outcome)

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -38,15 +38,27 @@ module PatientSessionStateMachineConcern
       end
 
       event :do_triage do
-        transitions from: %i[consent_given_triage_needed consent_given_triage_not_needed triaged_kept_in_triage],
+        transitions from: %i[
+                      consent_given_triage_needed
+                      consent_given_triage_not_needed
+                      triaged_kept_in_triage
+                    ],
                     to: :triaged_ready_to_vaccinate,
                     if: :triage_ready_to_vaccinate?
 
-        transitions from: %i[consent_given_triage_needed consent_given_triage_not_needed triaged_kept_in_triage],
+        transitions from: %i[
+                      consent_given_triage_needed
+                      consent_given_triage_not_needed
+                      triaged_kept_in_triage
+                    ],
                     to: :triaged_do_not_vaccinate,
                     if: :triage_do_not_vaccinate?
 
-        transitions from: %i[consent_given_triage_needed consent_given_triage_not_needed triaged_kept_in_triage],
+        transitions from: %i[
+                      consent_given_triage_needed
+                      consent_given_triage_not_needed
+                      triaged_kept_in_triage
+                    ],
                     to: :triaged_kept_in_triage,
                     if: :triage_keep_in_triage?
       end

--- a/app/models/consent_response.rb
+++ b/app/models/consent_response.rb
@@ -64,27 +64,33 @@ class ConsentResponse < ApplicationRecord
   validates :parent_name, presence: true, on: :edit_who
   validates :parent_phone, presence: true, on: :edit_who
   validates :parent_relationship,
-    inclusion: { in: parent_relationships.keys },
-    presence: true,
-    on: :edit_who
+            inclusion: {
+              in: parent_relationships.keys
+            },
+            presence: true,
+            on: :edit_who
   validates :parent_relationship_other,
-    presence: true,
-    if: -> { parent_relationship == "other" },
-    on: :edit_who
+            presence: true,
+            if: -> { parent_relationship == "other" },
+            on: :edit_who
 
   validates :consent,
-    inclusion: { in: consents.keys },
-    presence: true,
-    on: :edit_consent
+            inclusion: {
+              in: consents.keys
+            },
+            presence: true,
+            on: :edit_consent
 
   validates :reason_for_refusal,
-    inclusion: { in: reason_for_refusals.keys },
-    presence: true,
-    on: :edit_reason
+            inclusion: {
+              in: reason_for_refusals.keys
+            },
+            presence: true,
+            on: :edit_reason
   validates :reason_for_refusal_other,
-    presence: true,
-    if: -> { reason_for_refusal == "other" },
-    on: :edit_reason
+            presence: true,
+            if: -> { reason_for_refusal == "other" },
+            on: :edit_reason
 
   HEALTH_QUESTIONS = {
     flu: [

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -31,11 +31,11 @@ class PatientSession < ApplicationRecord
   has_many :vaccination_records
 
   validates :gillick_competent,
-    inclusion: { in: [true, false] },
-    on: :edit_gillick
-  validates :gillick_competence_notes,
-    presence: true,
-    on: :edit_gillick
+            inclusion: {
+              in: [true, false]
+            },
+            on: :edit_gillick
+  validates :gillick_competence_notes, presence: true, on: :edit_gillick
 
   def consent_response
     patient.consent_response_for_campaign(session.campaign)
@@ -46,8 +46,7 @@ class PatientSession < ApplicationRecord
   end
 
   def able_to_vaccinate?
-    !unable_to_vaccinate? &&
-    !unable_to_vaccinate_not_assessed? &&
-    !unable_to_vaccinate_not_gillick_competent?
+    !unable_to_vaccinate? && !unable_to_vaccinate_not_assessed? &&
+      !unable_to_vaccinate_not_gillick_competent?
   end
 end

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -28,9 +28,11 @@ class Triage < ApplicationRecord
   enum :status, %i[ready_to_vaccinate do_not_vaccinate needs_follow_up]
 
   validates :status,
-    presence: true,
-    inclusion: { in: statuses.keys },
-    on: :edit_questions
+            presence: true,
+            inclusion: {
+              in: statuses.keys
+            },
+            on: :edit_questions
 
   def triage_complete?
     ready_to_vaccinate? || do_not_vaccinate?

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -32,9 +32,7 @@ class VaccinationRecord < ApplicationRecord
   belongs_to :batch, optional: true
   has_one :vaccine, through: :batch
 
-  enum :delivery_method,
-       %w[intramuscular subcutaneous],
-       prefix: true
+  enum :delivery_method, %w[intramuscular subcutaneous], prefix: true
   enum :delivery_site,
        %w[
          left_arm
@@ -62,39 +60,36 @@ class VaccinationRecord < ApplicationRecord
        ]
 
   validates :administered, inclusion: [true, false]
-  validates :batch_id,
-            presence: true,
-            on: :edit_batch,
-            if: -> { administered }
+  validates :batch_id, presence: true, on: :edit_batch, if: -> { administered }
   validates :delivery_site,
             presence: true,
             inclusion: {
-              in: delivery_sites.keys,
+              in: delivery_sites.keys
             },
             if: -> { administered && !delivery_site_other }
   validates :delivery_method,
             presence: true,
             inclusion: {
-              in: delivery_methods.keys,
+              in: delivery_methods.keys
             },
             if: -> { administered && delivery_site.present? }
   validates :delivery_site,
             presence: true,
             inclusion: {
-              in: delivery_sites.keys,
+              in: delivery_sites.keys
             },
             on: :edit_delivery,
             if: -> { administered }
   validates :delivery_method,
             presence: true,
             inclusion: {
-              in: delivery_methods.keys,
+              in: delivery_methods.keys
             },
             on: :edit_delivery,
             if: -> { administered }
   validates :reason,
             inclusion: {
-              in: reasons.keys,
+              in: reasons.keys
             },
             on: :edit_reason,
             if: -> { !administered }

--- a/config/initializers/govuk_components.rb
+++ b/config/initializers/govuk_components.rb
@@ -1,3 +1,1 @@
-Govuk::Components.configure do |conf|
-  conf.brand = "nhsuk"
-end
+Govuk::Components.configure { |conf| conf.brand = "nhsuk" }

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,18 +1,19 @@
-require 'active_support/parameter_filter'
+require "active_support/parameter_filter"
 
 Sentry.init do |config|
-  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
   config.traces_sample_rate = 1.0
 
   rails_filter_parameters =
     Rails.application.config.filter_parameters.map(&:to_s)
 
-  sensitive_env_vars = ENV.select do |key, _v|
-    rails_filter_parameters.any? do |parameter|
-      key.downcase.include?(parameter)
+  sensitive_env_vars =
+    ENV.select do |key, _v|
+      rails_filter_parameters.any? do |parameter|
+        key.downcase.include?(parameter)
+      end
     end
-  end
 
   sensitive_values_pattern = Regexp.union(sensitive_env_vars.values)
 
@@ -24,11 +25,11 @@ Sentry.init do |config|
     end
   end
 
-  combined_filter = ActiveSupport::ParameterFilter.new(
-    Rails.application.config.filter_parameters + [sensitive_value_filter],
-  )
+  combined_filter =
+    ActiveSupport::ParameterFilter.new(
+      Rails.application.config.filter_parameters + [sensitive_value_filter]
+    )
 
-  config.before_send = lambda do |event, _hint|
-    combined_filter.filter(event.to_hash)
-  end
+  config.before_send =
+    lambda { |event, _hint| combined_filter.filter(event.to_hash) }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,12 @@ Rails.application.routes.draw do
       resource :vaccinations, only: %i[create show update] do
         get "history", on: :member
 
-        resource "batch", only: %i[edit update], controller: "vaccinations/batches"
-        resource "delivery_site", only: %i[edit update], controller: "vaccinations/delivery_site"
+        resource "batch",
+                 only: %i[edit update],
+                 controller: "vaccinations/batches"
+        resource "delivery_site",
+                 only: %i[edit update],
+                 controller: "vaccinations/delivery_site"
         get "edit/reason", action: "edit_reason", on: :member
         get "confirm", on: :member
         put "record", on: :member

--- a/db/migrate/20230721120653_create_campaign_vaccines_join_table.rb
+++ b/db/migrate/20230721120653_create_campaign_vaccines_join_table.rb
@@ -4,17 +4,16 @@ class CreateCampaignVaccinesJoinTable < ActiveRecord::Migration[7.0]
       t.index %i[campaign_id vaccine_id]
       t.index %i[vaccine_id campaign_id]
     end
-    Campaign.all.each do |c|
-      c.vaccines << Vaccine.find(c.vaccine_id)
-    end
+    Campaign.all.each { |c| c.vaccines << Vaccine.find(c.vaccine_id) }
     remove_column :campaigns, :vaccine_id
   end
 
   def down
     add_reference :campaigns, :vaccine, foreign_key: true
-    Campaign.all.includes(:vaccines).each do |c|
-      c.update(vaccine_id: c.vaccines.first.id)
-    end
+    Campaign
+      .all
+      .includes(:vaccines)
+      .each { |c| c.update(vaccine_id: c.vaccines.first.id) }
     drop_join_table :campaigns, :vaccines
     change_column_null :campaigns, :vaccine_id, false
   end

--- a/db/migrate/20230724141314_add_parent_info_to_patient.rb
+++ b/db/migrate/20230724141314_add_parent_info_to_patient.rb
@@ -1,12 +1,12 @@
 class AddParentInfoToPatient < ActiveRecord::Migration[7.0]
   def change
     change_table :patients, bulk: true do |t|
-      t.text    :parent_name
+      t.text :parent_name
       t.integer :parent_relationship
-      t.text    :parent_relationship_other
-      t.text    :parent_email
-      t.text    :parent_phone
-      t.text    :parent_info_source
+      t.text :parent_relationship_other
+      t.text :parent_email
+      t.text :parent_phone
+      t.text :parent_info_source
     end
   end
 end

--- a/db/migrate/20230725135855_add_gillick_competence_details_to_consent_response.rb
+++ b/db/migrate/20230725135855_add_gillick_competence_details_to_consent_response.rb
@@ -1,4 +1,6 @@
-class AddGillickCompetenceDetailsToConsentResponse < ActiveRecord::Migration[7.0]
+class AddGillickCompetenceDetailsToConsentResponse < ActiveRecord::Migration[
+  7.0
+]
   def change
     add_column :consent_responses, :gillick_competence_details, :text
   end

--- a/db/migrate/20230726085134_remove_gillick_competence_details_from_consent_response.rb
+++ b/db/migrate/20230726085134_remove_gillick_competence_details_from_consent_response.rb
@@ -1,4 +1,6 @@
-class RemoveGillickCompetenceDetailsFromConsentResponse < ActiveRecord::Migration[7.0]
+class RemoveGillickCompetenceDetailsFromConsentResponse < ActiveRecord::Migration[
+  7.0
+]
   def change
     remove_column :consent_responses, :gillick_competence_details, :text
   end

--- a/db/migrate/20230731094158_install_audited.rb
+++ b/db/migrate/20230731094158_install_audited.rb
@@ -2,7 +2,7 @@
 
 class InstallAudited < ActiveRecord::Migration[7.0]
   def self.up
-    create_table :audits, force: true do |t|  # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :audits, force: true do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.column :auditable_id, :integer
       t.column :auditable_type, :string
       t.column :associated_id, :integer
@@ -19,9 +19,13 @@ class InstallAudited < ActiveRecord::Migration[7.0]
       t.column :created_at, :datetime
     end
 
-    add_index :audits, [:auditable_type, :auditable_id, :version], name: 'auditable_index'
-    add_index :audits, [:associated_type, :associated_id], name: 'associated_index'
-    add_index :audits, [:user_id, :user_type], name: 'user_index'
+    add_index :audits,
+              %i[auditable_type auditable_id version],
+              name: "auditable_index"
+    add_index :audits,
+              %i[associated_type associated_id],
+              name: "associated_index"
+    add_index :audits, %i[user_id user_type], name: "user_index"
     add_index :audits, :request_uuid
     add_index :audits, :created_at
   end

--- a/db/migrate/20230731124921_move_triage_to_patient_session.rb
+++ b/db/migrate/20230731124921_move_triage_to_patient_session.rb
@@ -1,8 +1,12 @@
 class MoveTriageToPatientSession < ActiveRecord::Migration[7.0]
   def up
     Triage.all.each do |triage|
-      ps = PatientSession.find_by! patient_id: triage.patient_id,
-                                   session_id: Session.find_by(campaign_id: triage.campaign_id).id
+      ps =
+        PatientSession.find_by! patient_id: triage.patient_id,
+                                session_id:
+                                  Session.find_by(
+                                    campaign_id: triage.campaign_id
+                                  ).id
       triage.patient_session_id = ps.id
       triage.save!
     end
@@ -10,8 +14,10 @@ class MoveTriageToPatientSession < ActiveRecord::Migration[7.0]
 
   def down
     Triage.all.each do |triage|
-      triage.patient_id = PatientSession.find(triage.patient_session_id).patient_id
-      triage.campaign_id = PatientSession.find(triage.patient_session_id).session.campaign_id
+      triage.patient_id =
+        PatientSession.find(triage.patient_session_id).patient_id
+      triage.campaign_id =
+        PatientSession.find(triage.patient_session_id).session.campaign_id
       triage.save!
     end
   end

--- a/lib/example_campaign_data.rb
+++ b/lib/example_campaign_data.rb
@@ -13,7 +13,7 @@ class ExampleCampaignData
         type: raw_data["type"],
         brand: vaccine["brand"],
         method: vaccine["method"].downcase,
-        batches: vaccine["batches"],
+        batches: vaccine["batches"]
       }
     end
   end
@@ -39,7 +39,7 @@ class ExampleCampaignData
       town: school_data["town"],
       county: school_data["county"],
       postcode: school_data["postcode"],
-      url: school_data["url"],
+      url: school_data["url"]
     }
   end
 
@@ -65,13 +65,13 @@ class ExampleCampaignData
         parent_relationship_other: patient["parentRelationshipOther"],
         parent_email: patient["parentEmail"],
         parent_phone: patient["parentPhone"],
-        parent_info_source: patient["parentInfoSource"],
+        parent_info_source: patient["parentInfoSource"]
       }
 
       if patient["triage"].present?
         attributes[:triage] = {
           status: patient["triage"]["status"],
-          notes: patient["triage"]["notes"],
+          notes: patient["triage"]["notes"]
         }
       end
 

--- a/lib/tasks/generate_model_office_data.rake
+++ b/lib/tasks/generate_model_office_data.rake
@@ -7,12 +7,21 @@ task :generate_model_office_data, [] => :environment do |_task, _args|
   target_filename = "db/sample_data/model-office.json"
 
   hpv_vaccine = FactoryBot.create(:vaccine, :hpv)
-  batches = FactoryBot.create_list(:batch, 3, vaccine: hpv_vaccine, days_to_expiry_range: 90..180)
+  batches =
+    FactoryBot.create_list(
+      :batch,
+      3,
+      vaccine: hpv_vaccine,
+      days_to_expiry_range: 90..180
+    )
   vaccines_data = [
     {
       brand: hpv_vaccine.brand,
       method: hpv_vaccine.method,
-      batches: batches.map { |batch| { name: batch.name, expiry: batch.expiry.iso8601 } }
+      batches:
+        batches.map do |batch|
+          { name: batch.name, expiry: batch.expiry.iso8601 }
+        end
     }
   ]
 
@@ -225,8 +234,12 @@ task :generate_model_office_data, [] => :environment do |_task, _args|
 
   # match mum and dad info for patients with parental consent
   patients_data.each do |patient|
-    next unless patient[:consent].present? && patient[:consent][:parentRelationship].in?(%w[mother
-father]) && patient[:consent][:parentRelationship] == patient[:parentRelationship]
+    unless patient[:consent].present? &&
+             patient[:consent][:parentRelationship].in?(%w[mother father]) &&
+             patient[:consent][:parentRelationship] ==
+               patient[:parentRelationship]
+      next
+    end
 
     patient[:parentName] = patient[:consent][:parentName]
     patient[:parentRelationship] = patient[:consent][:parentRelationship]

--- a/lib/tasks/load_campaign_example.rake
+++ b/lib/tasks/load_campaign_example.rake
@@ -24,7 +24,7 @@ task :load_campaign_example, [:example_file] => :environment do |_task, args|
     session =
       Session.find_or_initialize_by(
         campaign:,
-        name: example.session_attributes[:name],
+        name: example.session_attributes[:name]
       )
     session.update!(example.session_attributes)
 
@@ -51,7 +51,9 @@ task :load_campaign_example, [:example_file] => :environment do |_task, args|
       next if consent_attributes.blank?
       consent_response =
         ConsentResponse.find_or_initialize_by(campaign:, patient:)
-      consent_response.update!(consent_attributes.merge(recorded_at: Time.zone.now))
+      consent_response.update!(
+        consent_attributes.merge(recorded_at: Time.zone.now)
+      )
       unless patient.consent_responses.include?(consent_response)
         patient.consent_responses << consent_response
       end

--- a/spec/components/app_consent_card_component_spec.rb
+++ b/spec/components/app_consent_card_component_spec.rb
@@ -6,15 +6,24 @@ RSpec.describe AppConsentCardComponent, type: :component do
   subject { page }
 
   let(:component) { described_class.new(consent_response:, patient:, session:) }
-  let(:consent_response) { create(:consent_response, campaign: session.campaign, patient:) }
+  let(:consent_response) do
+    create(:consent_response, campaign: session.campaign, patient:)
+  end
   let(:patient) { session.patients.first }
   let(:session) { create(:session) }
 
   context "when consent is present" do
     it { should have_css("h2", text: "Consent") }
-    it { should have_css("dd", text: consent_response.who_responded.capitalize) }
+    it do
+      should have_css("dd", text: consent_response.who_responded.capitalize)
+    end
     it { should have_css("dd", text: consent_response.parent_name) }
-    it { should have_css("dd", text: consent_response.created_at.to_fs(:nhsuk_date)) }
+    it do
+      should have_css(
+               "dd",
+               text: consent_response.created_at.to_fs(:nhsuk_date)
+             )
+    end
     it { should have_css("dd", text: "Website") }
   end
 

--- a/spec/components/app_gillick_card_component_spec.rb
+++ b/spec/components/app_gillick_card_component_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe AppGillickCardComponent, type: :component do
   subject { page }
 
   let(:component) { described_class.new(consent_response:, patient_session:) }
-  let(:consent_response) do
-    create(:consent_response)
-  end
+  let(:consent_response) { create(:consent_response) }
   let(:patient_session) { create(:patient_session, gillick_competent:) }
   let(:gillick_competent) { true }
 

--- a/spec/components/app_patient_medical_history_card_component_spec.rb
+++ b/spec/components/app_patient_medical_history_card_component_spec.rb
@@ -65,9 +65,7 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
              campaign: session.campaign
     end
     let(:triage_notes) { "These are triage notes" }
-    let(:triage) do
-      create :triage, patient_session:, notes: triage_notes
-    end
+    let(:triage) { create :triage, patient_session:, notes: triage_notes }
 
     it "renders correctly" do
       expect(page).to have_css("h2:nth(2)", text: "Triage notes")
@@ -86,9 +84,7 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
              patient:,
              campaign: session.campaign
     end
-    let(:triage) do
-      create :triage, patient_session:, notes: nil
-    end
+    let(:triage) { create :triage, patient_session:, notes: nil }
 
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage complete - no notes")
@@ -110,9 +106,7 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
       ]
     end
     let(:triage_notes) { "These are triage notes" }
-    let(:triage) do
-      create :triage, patient_session:, notes: triage_notes
-    end
+    let(:triage) { create :triage, patient_session:, notes: triage_notes }
 
     it "renders correctly" do
       expect(page).to have_css("h2:nth(2)", text: "Triage notes")
@@ -134,9 +128,7 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
         }
       ]
     end
-    let(:triage) do
-      create :triage, patient_session:, notes: nil
-    end
+    let(:triage) { create :triage, patient_session:, notes: nil }
 
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage complete - no notes")

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -19,17 +19,21 @@ RSpec.describe AppStatusBannerComponent, type: :component do
   end
 
   context "state is consent_given_triage_not_needed" do
-    let(:patient_session) { create :patient_session, :consent_given_triage_not_needed }
+    let(:patient_session) do
+      create :patient_session, :consent_given_triage_not_needed
+    end
 
     it { should have_css(".app-consent-banner--purple") }
     it { should have_text("Ready to vaccinate") }
-    it 'does not provide an explanation as no triage took place' do
+    it "does not provide an explanation as no triage took place" do
       expect(component.explanation).to be_blank
     end
   end
 
   context "state is consent_given_triage_needed" do
-    let(:patient_session) { create :patient_session, :consent_given_triage_needed }
+    let(:patient_session) do
+      create :patient_session, :consent_given_triage_needed
+    end
 
     it { should have_css(".app-consent-banner--blue") }
     it { should have_text("Triage needed") }
@@ -47,8 +51,10 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--red") }
     it { should have_text("Do not vaccinate") }
-    it 'explains who took the decision that the patient should not be vaccinated' do
-      expect(component.explanation).to eq('A nurse decided that Alya Merton should not be vaccinated.')
+    it "explains who took the decision that the patient should not be vaccinated" do
+      expect(component.explanation).to eq(
+        "A nurse decided that Alya Merton should not be vaccinated."
+      )
     end
   end
 
@@ -60,12 +66,16 @@ RSpec.describe AppStatusBannerComponent, type: :component do
   end
 
   context "state is triaged_ready_to_vaccinate" do
-    let(:patient_session) { create :patient_session, :triaged_ready_to_vaccinate }
+    let(:patient_session) do
+      create :patient_session, :triaged_ready_to_vaccinate
+    end
 
     it { should have_css(".app-consent-banner--purple") }
     it { should have_text("Ready to vaccinate") }
-    it 'explains who took the decision that the patient should be vaccinated' do
-      expect(component.explanation).to eq('A nurse decided that Alya Merton can be vaccinated.')
+    it "explains who took the decision that the patient should be vaccinated" do
+      expect(component.explanation).to eq(
+        "A nurse decided that Alya Merton can be vaccinated."
+      )
     end
   end
 
@@ -74,8 +84,10 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--orange") }
     it { should have_text("Could not vaccinate") }
-    it 'explains who took the decision that the patient should be vaccinated' do
-      expect(component.explanation).to include('Alya Merton had contraindications')
+    it "explains who took the decision that the patient should be vaccinated" do
+      expect(component.explanation).to include(
+        "Alya Merton had contraindications"
+      )
     end
   end
 
@@ -84,9 +96,11 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-consent-banner--green") }
     it { should have_text("Vaccinated") }
-    it 'explains who gave consent' do
+    it "explains who gave consent" do
       who_responded = patient_session.consent_response.who_responded
-      expect(component.explanation).to include("Their #{who_responded} gave consent")
+      expect(component.explanation).to include(
+        "Their #{who_responded} gave consent"
+      )
     end
   end
 end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -27,9 +27,7 @@ FactoryBot.define do
 
     trait :consent_given_triage_not_needed do
       state { "consent_given_triage_not_needed" }
-      patient do
-        create :patient, :consent_given_triage_not_needed, session:
-      end
+      patient { create :patient, :consent_given_triage_not_needed, session: }
     end
 
     trait :consent_given_triage_needed do
@@ -79,9 +77,7 @@ FactoryBot.define do
       triage { [create(:triage, status: :ready_to_vaccinate)] }
 
       after :create do |patient_session|
-        create :vaccination_record,
-               administered: true,
-               patient_session:
+        create :vaccination_record, administered: true, patient_session:
       end
     end
   end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -33,10 +33,16 @@ FactoryBot.define do
       session { create :session }
       campaign { session.campaign }
       parent_sex { %w[male female].sample }
-      parent_first_name { parent_sex == "male" ? Faker::Name.masculine_name : Faker::Name.feminine_name }
+      parent_first_name do
+        if parent_sex == "male"
+          Faker::Name.masculine_name
+        else
+          Faker::Name.feminine_name
+        end
+      end
     end
 
-    nhs_number { rand(10 ** 10) }
+    nhs_number { rand(10**10) }
     sex { %w[Male Female].sample }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
@@ -55,9 +61,7 @@ FactoryBot.define do
     end
 
     trait :consent_given_triage_not_needed do
-      consent_responses do
-        [create(:consent_response, :given, campaign:)]
-      end
+      consent_responses { [create(:consent_response, :given, campaign:)] }
     end
 
     trait :consent_given_triage_needed do
@@ -67,7 +71,9 @@ FactoryBot.define do
     end
 
     trait :consent_refused do
-      consent_responses { [create(:consent_response, :refused, :from_mum, campaign:)] }
+      consent_responses do
+        [create(:consent_response, :refused, :from_mum, campaign:)]
+      end
     end
 
     trait :no_parent_info do

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -15,15 +15,12 @@
 #
 FactoryBot.define do
   factory :vaccine do
-
     initialize_with { Vaccine.find_or_initialize_by(type:, brand:, method:) }
 
     hpv
 
     trait :with_batches do
-      transient do
-        batch_count { 3 }
-      end
+      transient { batch_count { 3 } }
 
       after(:create) do |vaccine, evaluator|
         create_list(:batch, evaluator.batch_count, vaccine:)

--- a/spec/models/concerns/human_enum_name_concern_spec.rb
+++ b/spec/models/concerns/human_enum_name_concern_spec.rb
@@ -1,25 +1,25 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe HumanEnumNameConcern do
   let(:dummy_class) do
-      Class.new do
-        include HumanEnumNameConcern
+    Class.new do
+      include HumanEnumNameConcern
 
-        attr_reader :status
+      attr_reader :status
 
-        def initialize(status:)
-          @status = status
-        end
+      def initialize(status:)
+        @status = status
+      end
 
-        def self.model_name
-          ActiveModel::Name.new(self, nil, "Dummy")
-        end
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "Dummy")
+      end
 
-        def [](attr)
-          send(attr)
-        end
+      def [](attr)
+        send(attr)
       end
     end
+  end
 
   describe ".human_enum_name" do
     subject { dummy_class.human_enum_name(enum_name, enum_value) }
@@ -70,8 +70,6 @@ RSpec.describe HumanEnumNameConcern do
 
       it { should eq "" }
     end
-
-
   end
 
   describe "#human_enum_name" do
@@ -79,12 +77,11 @@ RSpec.describe HumanEnumNameConcern do
       dummy_class.new(status: :test_status).human_enum_name(:status)
     end
 
-   before do
+    before do
       allow(dummy_class).to receive(:human_enum_name).and_return("Test status")
     end
 
     # Cannot instantiate ActiveRecord
-   it { should eq "Test status" }
+    it { should eq "Test status" }
   end
-
 end

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         :consent_given,
         patient:,
         parent_relationship: :mother,
-        campaign: session.campaign,
+        campaign: session.campaign
       )
       patient_session.do_consent
       expect(patient_session).to be_consent_given_triage_not_needed
@@ -254,7 +254,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         :vaccination_record,
         patient_session:,
         administered: true,
-        delivery_site: :right_arm,
+        delivery_site: :right_arm
       )
       patient_session.do_vaccination
       expect(patient_session).to be_vaccinated
@@ -272,7 +272,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         :consent_refused,
         patient:,
         parent_relationship: :mother,
-        campaign: session.campaign,
+        campaign: session.campaign
       )
       patient_session.do_consent
       expect(patient_session).to be_consent_refused
@@ -290,18 +290,13 @@ RSpec.describe PatientSessionStateMachineConcern do
         :consent_given,
         patient:,
         parent_relationship: :other,
-        campaign: session.campaign,
+        campaign: session.campaign
       )
       patient_session.do_consent
       expect(patient_session).to be_consent_given_triage_needed
 
       # follow-up needed
-      triage =
-        create(
-          :triage,
-          patient_session:,
-          status: :needs_follow_up,
-        )
+      triage = create(:triage, patient_session:, status: :needs_follow_up)
       patient_session.do_triage
       expect(patient_session).to be_triaged_kept_in_triage
 
@@ -315,7 +310,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         :vaccination_record,
         patient_session:,
         administered: true,
-        delivery_site: :left_arm,
+        delivery_site: :left_arm
       )
       patient_session.do_vaccination
       expect(patient_session).to be_vaccinated
@@ -333,17 +328,13 @@ RSpec.describe PatientSessionStateMachineConcern do
         :consent_given,
         patient:,
         parent_relationship: :other,
-        campaign: session.campaign,
+        campaign: session.campaign
       )
       patient_session.do_consent
       expect(patient_session).to be_consent_given_triage_needed
 
       # triage decides not to vaccinate
-      create(
-        :triage,
-        patient_session:,
-        status: :do_not_vaccinate,
-      )
+      create(:triage, patient_session:, status: :do_not_vaccinate)
       patient_session.do_triage
       expect(patient_session).to be_triaged_do_not_vaccinate
     end
@@ -360,7 +351,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         :consent_given,
         patient:,
         parent_relationship: :mother,
-        campaign: session.campaign,
+        campaign: session.campaign
       )
       patient_session.do_consent
       expect(patient_session).to be_consent_given_triage_not_needed
@@ -383,17 +374,13 @@ RSpec.describe PatientSessionStateMachineConcern do
         :consent_given,
         patient:,
         parent_relationship: :mother,
-        campaign: session.campaign,
+        campaign: session.campaign
       )
       patient_session.do_consent
       expect(patient_session).to be_consent_given_triage_not_needed
 
       # triage decides not to vaccinate
-      create(
-        :triage,
-        patient_session:,
-        status: :do_not_vaccinate,
-      )
+      create(:triage, patient_session:, status: :do_not_vaccinate)
       patient_session.do_triage
       expect(patient_session).to be_triaged_do_not_vaccinate
     end

--- a/spec/routing/vaccinations_routing_spec.rb
+++ b/spec/routing/vaccinations_routing_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe VaccinationsController, type: :routing do
     it "routes to #index" do
       expect(get: "/sessions/1/vaccinations").to route_to(
         "vaccinations#index",
-        id: "1",
+        id: "1"
       )
     end
   end


### PR DESCRIPTION
The new Prettier version requires us to explicitly call out plugins using a .prettierrc.