### PR TITLE
Add password protection to staging environment 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,10 @@ inherit_mode:
 Style/NumericLiterals:
   Exclude:
     - db/schema.rb
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - staging
+    - production

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
 
-  if Rails.env.production?
+  if Rails.env.staging? || Rails.env.production?
     http_basic_authenticate_with name: Settings.support_username,
                                  password: Settings.support_password,
                                  message:


### PR DESCRIPTION
This allows us to use `staging` instead of `production` on Heroku.