### PR TITLE
Add intitializer for production checks

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,8 @@
   "environments": {
     "review": {
       "env": {
+        "RACK_ENV": "staging",
+        "RAILS_ENV": "staging",
         "RCVAPP__SUPPORT_USERNAME": "test",
         "RCVAPP__SUPPORT_PASSWORD": "test"
       }

--- a/config/initializers/check_production.rb
+++ b/config/initializers/check_production.rb
@@ -1,0 +1,12 @@
+if Rails.env.production?
+  if credentials.dig(:active_record_encryption, :primary_key).blank?
+    raise "Application is running in production mode but Active Record
+    Encryption is not set up. Please set up Active Record Encryption. See
+    https://edgeguides.rubyonrails.org/active_record_encryption.html"
+  end
+
+  if ENV.fetch("SENTRY_DSN", "").blank?
+    raise "Application is running in production mode but SENTRY_DSN is not set
+    up. Please set up Sentry."
+  end
+end


### PR DESCRIPTION
We want to ensure that when we release the application, we don't forget to configure certain things, like Active Record Encryption. We can codify these to reduce the chance of this occuring in production mode.