### PR TITLE
Show validation errors when submitting a blank triage

### DIFF
--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -3,7 +3,7 @@ class TriageController < ApplicationController
   before_action :set_patient, only: %i[show create update]
   before_action :set_patient_session, only: %i[create update show]
   before_action :set_triage, only: %i[show]
-  before_action :set_consent_response, only: %i[show]
+  before_action :set_consent_response, only: %i[show create update]
   before_action :set_vaccination_record, only: %i[show]
 
   layout "two_thirds", except: %i[index]
@@ -45,7 +45,8 @@ class TriageController < ApplicationController
 
   def create
     @triage = @patient_session.triage.new
-    if @triage.update(triage_params)
+    @triage.assign_attributes triage_params
+    if @triage.save(context: :consent)
       @patient_session.do_triage!
       redirect_to triage_session_path(@session),
                   flash: {
@@ -65,7 +66,8 @@ class TriageController < ApplicationController
 
   def update
     @triage = @patient_session.triage.last
-    if @triage.update(triage_params)
+    @triage.assign_attributes triage_params
+    if @triage.save(context: :consent)
       @patient_session.do_triage!
       redirect_to triage_session_path(@session),
                   flash: {

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -32,7 +32,7 @@ class Triage < ApplicationRecord
             inclusion: {
               in: statuses.keys
             },
-            on: :edit_questions
+            on: %i[edit_questions consent]
 
   def triage_complete?
     ready_to_vaccinate? || do_not_vaccinate?


### PR DESCRIPTION
This prevents the 500 from occuring due to attempting to progress the state machine with no triage status.

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/18589924-64da-493e-82fe-e5fd17880d5d)
