### PR TITLE
Add validations specs

### DIFF
--- a/tests/consent_gillick_validations.spec.ts
+++ b/tests/consent_gillick_validations.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, Page } from "@playwright/test";
+
+let p: Page;
+
+test("Consent via Gillick competence validations", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+
+  await given_i_am_assessing_a_child_for_gillick_competence();
+  await when_i_continue_without_entering_anything();
+  await then_the_gillick_assessment_validation_errors_are_displayed();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function given_i_am_assessing_a_child_for_gillick_competence() {
+  await p.goto("/sessions/1/vaccinations");
+  await p.getByRole("tab", { name: "Action needed" }).click();
+  await p.getByRole("link", { name: "Alexandra Sipes" }).click();
+
+  await p.getByRole("radio", { name: "Gillick competence" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+
+  await p.getByRole("button", { name: "Give your assessment" }).click();
+}
+
+async function when_i_continue_without_entering_anything() {
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_the_gillick_assessment_validation_errors_are_displayed() {
+  const alert = p.getByRole("alert");
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText("Choose if they are Gillick competent");
+  await expect(alert).toContainText("Enter details of your assessment");
+}

--- a/tests/consent_refused_validations.spec.ts
+++ b/tests/consent_refused_validations.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect, Page } from "@playwright/test";
+
+let p: Page;
+
+test("Consent refused validations", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+
+  await given_i_am_on_the_reasons_for_consent_refusal_page();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_reasons_for_consent_refusal_validation_errors();
+
+  await given_i_select_other_reason();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_other_reason_validation_errors();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function given_i_am_on_the_reasons_for_consent_refusal_page() {
+  await p.goto("/sessions/1/triage");
+  await p.getByRole("tab", { name: "Get consent" }).click();
+  await p.getByRole("link", { name: "Alexandra Sipes" }).click();
+  await p.getByRole("button", { name: "Get consent" }).click();
+
+  await p.fill('[name="consent[parent_name]"]', "Carl Sipes");
+  await p.fill('[name="consent[parent_phone]"]', "07700900000");
+  await p.getByRole("radio", { name: "Dad" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+
+  await p.getByRole("radio", { name: "No, they do not agree" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function when_i_continue_without_entering_anything() {
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_reasons_for_consent_refusal_validation_errors() {
+  await expect(p.getByRole("alert").getByText("Choose a reason")).toBeVisible();
+}
+
+async function given_i_select_other_reason() {
+  await p.getByRole("radio", { name: "Other" }).click();
+}
+
+async function then_i_see_the_other_reason_validation_errors() {
+  await expect(p.getByRole("alert").getByText("Enter a reason")).toBeVisible();
+}

--- a/tests/consent_validations.spec.ts
+++ b/tests/consent_validations.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, Page } from "@playwright/test";
+
+let p: Page;
+
+test("Consent validations", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+
+  // Who are you getting consent from validations
+  await given_i_am_on_the_who_am_i_contacting_for_consent_page();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_who_i_am_contacting_validation_errors();
+
+  await given_i_select_other_relationship();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_other_relationship_validation_errors();
+
+  // Consent response validations
+  await given_i_move_on_to_the_consent_response_page();
+  // TODO: There is currently a bug where submitting this returns an empty response.
+  // await when_i_continue_without_entering_anything();
+  // await then_i_see_the_consent_response_form_validation_errors();
+
+  // Triage details validations
+  await given_i_move_on_to_the_triage_details_page();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_triage_details_validation_errors();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function given_i_am_on_the_who_am_i_contacting_for_consent_page() {
+  await p.goto("/sessions/1/triage");
+  await p.getByRole("tab", { name: "Get consent" }).click();
+  await p.getByRole("link", { name: "Alexandra Sipes" }).click();
+  await p.getByRole("button", { name: "Get consent" }).click();
+}
+
+async function when_i_continue_without_entering_anything() {
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_consent_response_form_validation_errors() {
+  await expect(
+    p.getByRole("alert").getByText("Choose yes or no"),
+  ).toBeVisible();
+}
+
+async function then_i_see_the_who_i_am_contacting_validation_errors() {
+  const alert = p.getByRole("alert");
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText("Enter a name");
+  await expect(alert).toContainText("Enter a phone number");
+  await expect(alert).toContainText("Choose a relationship");
+}
+
+async function given_i_select_other_relationship() {
+  await p.getByRole("radio", { name: "Other" }).click();
+}
+
+async function then_i_see_the_other_relationship_validation_errors() {
+  await expect(
+    p.getByRole("alert").getByText("Enter a relationship"),
+  ).toBeVisible();
+}
+
+async function given_i_move_on_to_the_consent_response_page() {
+  await p.fill('[name="consent[parent_name]"]', "Carl Sipes");
+  await p.fill('[name="consent[parent_phone]"]', "07700900000");
+  await p.getByRole("radio", { name: "Dad" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function given_i_move_on_to_the_triage_details_page() {
+  await p.getByRole("radio", { name: "Yes, they agree" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_triage_details_validation_errors() {
+  await expect(p.getByRole("alert").getByText("Choose a status")).toBeVisible();
+}

--- a/tests/triage_validations.spec.ts
+++ b/tests/triage_validations.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect, Page } from "@playwright/test";
+
+let p: Page;
+
+test("Triage validations", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+
+  // Triage page validation
+  await given_i_am_on_the_triage_page_for_a_child();
+  await when_i_continue_without_entering_anything();
+  await then_the_triage_validation_errors_are_displayed();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function given_i_am_on_the_triage_page_for_a_child() {
+  await p.goto("/sessions/1/triage");
+  await p.getByRole("tab", { name: "Needs triage" }).click();
+  await p.getByRole("link", { name: "Blaine DuBuque" }).click();
+}
+
+async function when_i_continue_without_entering_anything() {
+  await p.getByRole("button", { name: "Save triage" }).click();
+}
+
+async function then_the_triage_validation_errors_are_displayed() {
+  await expect(p.getByRole("alert").getByText("Choose a status")).toBeVisible();
+}

--- a/tests/vaccination_refused_validations.spec.ts
+++ b/tests/vaccination_refused_validations.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, Page } from "@playwright/test";
+
+let p: Page;
+
+test("Vaccination refused validations", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+
+  await given_i_am_on_the_reason_vaccination_not_given_page_for_a_child();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_reason_for_not_giving_the_vaccination_validation_errors();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function given_i_am_on_the_reason_vaccination_not_given_page_for_a_child() {
+  await p.goto("/sessions/1/vaccinations");
+  await p.getByRole("tab", { name: "Action needed" }).click();
+  await p.getByRole("link", { name: "Ernie Funk" }).click();
+
+  await p.getByRole("radio", { name: "No" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function when_i_continue_without_entering_anything() {
+  p.click("text=Continue");
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_reason_for_not_giving_the_vaccination_validation_errors() {
+  await expect(
+    p.locator(".nhsuk-error-message", { hasText: "Choose a reason" }),
+  ).toBeVisible();
+}

--- a/tests/vaccination_validations.spec.ts
+++ b/tests/vaccination_validations.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, Page } from "@playwright/test";
+
+let p: Page;
+
+test("Vaccination validations", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+
+  await given_i_am_on_the_vaccination_page_for_a_child();
+  await when_i_continue_without_entering_anything();
+  await then_the_vaccination_validation_errors_are_displayed();
+
+  await given_i_select_that_they_got_the_vaccine();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_vaccination_site_validation_errors();
+
+  await given_i_move_on_to_the_how_the_vaccine_was_given_page();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_how_the_vaccine_was_given_validation_errors();
+
+  await given_i_move_on_to_the_batch_selection_page();
+  await when_i_continue_without_entering_anything();
+  await then_i_see_the_batch_validation_errors();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function given_i_am_on_the_vaccination_page_for_a_child() {
+  await p.goto("/sessions/1/vaccinations");
+  await p.getByRole("tab", { name: "Action needed" }).click();
+  await p.getByRole("link", { name: "Ernie Funk" }).click();
+}
+
+async function when_i_continue_without_entering_anything() {
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_the_vaccination_validation_errors_are_displayed() {
+  await expect(
+    p.getByRole("alert").getByText("Choose if they got the vaccine"),
+  ).toBeVisible();
+}
+
+async function given_i_select_that_they_got_the_vaccine() {
+  await p.getByRole("radio", { name: "Yes" }).click();
+}
+
+async function then_i_see_the_vaccination_site_validation_errors() {
+  await expect(
+    p.getByRole("alert").getByText("Choose a delivery site"),
+  ).toBeVisible();
+}
+
+async function given_i_move_on_to_the_how_the_vaccine_was_given_page() {
+  await p.getByRole("radio", { name: "Other" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_how_the_vaccine_was_given_validation_errors() {
+  await expect(
+    p.locator(".nhsuk-error-message", {
+      hasText: "Choose a method of delivery",
+    }),
+  ).toBeVisible();
+
+  await expect(
+    p.locator(".nhsuk-error-message", { hasText: "Choose a delivery site" }),
+  ).toBeVisible();
+}
+
+async function given_i_move_on_to_the_batch_selection_page() {
+  await p.getByRole("radio", { name: "Intramuscular" }).click();
+  await p.getByRole("radio", { name: "Left thigh" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_batch_validation_errors() {
+  await expect(
+    p.locator(".nhsuk-error-message", { hasText: "Choose a batch" }),
+  ).toBeVisible();
+}


### PR DESCRIPTION
These tests that validations errors are displayed on forms. With the complexity of the various form journeys we have, and given the setting that this tool will be used, these are useful to ensure that the service communicates errors in the correct way to nurses.