### PR TITLE
Error when revisiting old forms

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
 
+  class UnprocessableEntity < StandardError
+  end
+
+  unless Rails.configuration.consider_all_requests_local
+    rescue_from UnprocessableEntity, with: :handle_unprocessable_entity
+  end
+
   if Rails.env.staging? || Rails.env.production?
     http_basic_authenticate_with name: Settings.support_username,
                                  password: Settings.support_password,
@@ -16,5 +23,9 @@ class ApplicationController < ActionController::Base
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "0"
+  end
+
+  def handle_unprocessable_entity(_exception)
+    render "errors/unprocessable_entity", status: :unprocessable_entity
   end
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -2,7 +2,8 @@ class ConsentsController < ApplicationController
   before_action :set_session
   before_action :set_patient
   before_action :set_patient_session
-  before_action :set_draft_consent
+  before_action :set_draft_consent, only: %i[create new]
+  before_action :get_draft_consent, except: %i[assessing_gillick create new]
   before_action :set_draft_triage, only: %i[edit_questions edit_confirm update]
   before_action :keep_consent_return_path, except: %i[record]
 
@@ -191,6 +192,15 @@ class ConsentsController < ApplicationController
         recorded_at: nil,
         campaign: @session.campaign
       )
+  end
+
+  def get_draft_consent
+    @draft_consent =
+      @patient.consents.find_by(recorded_at: nil, campaign: @session.campaign)
+
+    unless @draft_consent
+      render "errors/unprocessable_entity", status: :unprocessable_entity
+    end
   end
 
   def set_draft_triage

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -2,7 +2,7 @@ class ConsentsController < ApplicationController
   before_action :set_session
   before_action :set_patient
   before_action :set_patient_session
-  before_action :set_draft_consent, only: %i[create new]
+  before_action :set_draft_consent, only: %i[assessing_gillick create new]
   before_action :get_draft_consent, except: %i[assessing_gillick create new]
   before_action :set_draft_triage, only: %i[edit_questions edit_confirm update]
   before_action :keep_consent_return_path, except: %i[record]
@@ -187,6 +187,10 @@ class ConsentsController < ApplicationController
   end
 
   def set_draft_consent
+    if @patient.consents.not_response_not_provided.any?
+      raise UnprocessableEntity
+    end
+
     @draft_consent =
       @patient.consents.find_or_initialize_by(
         recorded_at: nil,

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -198,9 +198,7 @@ class ConsentsController < ApplicationController
     @draft_consent =
       @patient.consents.find_by(recorded_at: nil, campaign: @session.campaign)
 
-    unless @draft_consent
-      render "errors/unprocessable_entity", status: :unprocessable_entity
-    end
+    raise UnprocessableEntity unless @draft_consent
   end
 
   def set_draft_triage

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,8 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  layout "two_thirds"
+
   def not_found
     render "not_found", status: :not_found
   end

--- a/app/controllers/vaccinations/batches_controller.rb
+++ b/app/controllers/vaccinations/batches_controller.rb
@@ -26,9 +26,11 @@ class Vaccinations::BatchesController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).find_or_initialize_by(
+      @patient.vaccination_records_for_session(@session).find_by(
         recorded_at: nil
       )
+
+    raise UnprocessableEntity unless @draft_vaccination_record
   end
 
   def set_patient

--- a/app/controllers/vaccinations/delivery_site_controller.rb
+++ b/app/controllers/vaccinations/delivery_site_controller.rb
@@ -36,9 +36,11 @@ class Vaccinations::DeliverySiteController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).find_or_initialize_by(
+      @patient.vaccination_records_for_session(@session).find_by(
         recorded_at: nil
       )
+
+    raise UnprocessableEntity unless @draft_vaccination_record
   end
 
   def set_patient

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -5,7 +5,8 @@ class VaccinationsController < ApplicationController
   before_action :set_patient_session,
                 only: %i[new confirm consent create record show update]
   before_action :set_draft_vaccination_record,
-                only: %i[new show confirm edit_reason record create update]
+                only: %i[show edit_reason create update]
+  before_action :set_draft_vaccination_record!, only: %i[confirm record]
 
   before_action :set_vaccination_record, only: %i[show confirm record]
   before_action :set_consent, only: %i[create show confirm update]
@@ -53,6 +54,11 @@ class VaccinationsController < ApplicationController
   end
 
   def new
+    if @patient.vaccination_records_for_session(@session).any?
+      raise UnprocessableEntity
+    end
+    @draft_vaccination_record =
+      @patient.vaccination_records_for_session(@session).new
   end
 
   def show
@@ -257,6 +263,11 @@ class VaccinationsController < ApplicationController
       @patient.vaccination_records_for_session(@session).find_or_initialize_by(
         recorded_at: nil
       )
+  end
+
+  def set_draft_vaccination_record!
+    set_draft_vaccination_record
+    raise UnprocessableEntity unless @draft_vaccination_record.persisted?
   end
 
   def set_vaccination_record

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,18 +1,15 @@
 <%= content_for :page_title, "Sorry, there’s a problem with the service" %>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <h1 class="nhsuk-heading-l">Sorry, there’s a problem with the service</h1>
+<h1 class="nhsuk-heading-l">Sorry, there’s a problem with the service</h1>
 
-    <p class="nhsuk-body">Try again later.</p>
+<p class="nhsuk-body">Try again later.</p>
 
-    <p class="nhsuk-body">
-      If you reached this page after submitting information then it has not
-      been saved. You’ll need to enter it again when the service is available.
-    </p>
-    <p class="nhsuk-body">
-      If you have any questions, please email us at <a class="nhsuk-link"
-        href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
-    </p>
-  </div>
-</div>
+<p class="nhsuk-body">
+  If you reached this page after submitting information then it has not
+  been saved. You’ll need to enter it again when the service is available.
+</p>
+<p class="nhsuk-body">
+  If you have any questions, please email us at
+  <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
+  <%= t('service.email') %></a>.
+</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,19 +1,15 @@
 <%= content_for :page_title, "Page not found" %>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <h1 class="nhsuk-heading-l">Page not found</h1>
-    <p class="nhsuk-body">
-      If you entered a web address, check it is correct.
-    </p>
-    <p class="nhsuk-body">
-      If you pasted the web address, check you copied the entire address.
-    </p>
-    <p class="nhsuk-body">
-      If the web address is correct or you selected a link or button and you
-      need to speak to someone about this problem, contact the <%=
-      t('service.name') %> team: <a class="nhsuk-link" href="mailto:<%=
-      t('service.email') %>"><%= t('service.email') %></a>.
-    </p>
-  </div>
-</div>
+<h1 class="nhsuk-heading-l">Page not found</h1>
+<p class="nhsuk-body">
+  If you entered a web address, check it is correct.
+</p>
+<p class="nhsuk-body">
+  If you pasted the web address, check you copied the entire address.
+</p>
+<p class="nhsuk-body">
+  If the web address is correct or you selected a link or button and you
+  need to speak to someone about this problem, contact the <%= t('service.name') %>
+  team: <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
+  <%= t('service.email') %></a>.
+</p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,15 +1,11 @@
 <%= content_for :page_title, 'Sorry, there’s a problem with the service' %>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <h1 class="nhsuk-heading-l">Sorry, there’s a problem with the service</h1>
+<h1 class="nhsuk-heading-l">Sorry, there’s a problem with the service</h1>
 
-    <p class="nhsuk-body">Try again later.</p>
+<p class="nhsuk-body">Try again later.</p>
 
-    <p class="nhsuk-body">
-      If you continue to see this error contact the <%= t('service.name')
-      %> team: <a class="nhsuk-link" href="mailto:<%= t('service.email') %>"><%=
-      t('service.email') %></a>.
-    </p>
-  </div>
-</div>
+<p class="nhsuk-body">
+  If you continue to see this error contact the <%= t('service.name') %>
+  team: <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
+  <%= t('service.email') %></a>.
+</p>


### PR DESCRIPTION
Users can use the browser back button to return to old forms that are part of the consent journey, resulting in undefined behaviour in the app. This change makes it clearer that what they are doing isn't supported by rendering errors when form pages are requested in an inconsistent state.

This change now renders the error `unprocessable entity` page instead of the form when there no `draft_consent` object on pages that require it. Only the `create` and `new` pages should be able to create these objects. However, a 500 error can still easily be triggered if the user creates another consent object by going back to the `assessing_gillick` page and restarts the journey there.

https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/450e2d74-c19e-4624-9ada-1adbf83d51d6

Unless we want to allow them to change the Gillick competence result, maybe we should raise the same `unprocessable entity` status when the revisit the `assessing_gillick` page.

This issues also still exists in the vaccinations controller, and probably the triage controller.

https://github.com/nhsuk/record-childrens-vaccinations/assets/15608/3ebd7511-a16e-4dd8-ba67-a31728397710

What still needs doing:

- [ ] Raise this error on `assessing_gillick` page.
- [ ] Raise these errors in vaccinations controllers.
- [ ] ~~Raise these errors in triage controllers.~~
