### PR TITLE
Populate page titles based on h1 content

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,30 @@
+module ApplicationHelper
+  def h1(text = nil, **options, &block)
+    title_text = options[:page_title] || text
+    options.delete(:page_title)
+
+    content_for(:page_title, title_text) unless content_for?(:page_title)
+
+    if block_given?
+      if title_text.blank?
+        raise ArgumentError, "Must provide title option when using block"
+      end
+      content_tag(:h1, options, &block)
+    else
+      content_tag(:h1, text, **options)
+    end
+  end
+
+  def page_title
+    title = content_for(:page_title)
+
+    if title.blank?
+      raise "No page title set. Either use the <%= h1 %> helper in your page, \
+or set it with content_for(:page_title)."
+    end
+
+    title = "Error: #{title}" if response.status == 422
+
+    [title, t("service.name")].join(" - ")
+  end
+end

--- a/app/views/consent_forms/confirm.html.erb
+++ b/app/views/consent_forms/confirm.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Check and confirm answers</h1>
+<%= h1 "Check and confirm answers", class: "nhsuk-heading-l" %>
 
 <%= govuk_button_to "Confirm",
                     url_for(action: :record),

--- a/app/views/consent_forms/start.html.erb
+++ b/app/views/consent_forms/start.html.erb
@@ -1,4 +1,4 @@
-<h1>Give or refuse consent for a flu vaccination</h1>
+<%= h1 "Give or refuse consent for a flu vaccination" %>
 
 <p>The vaccination is given as a painless spray into each nostril. It is safe
 and effective in helping to protect children against flu.</p>

--- a/app/views/consents/assessing_gillick.html.erb
+++ b/app/views/consents/assessing_gillick.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Assessing Gillick competence</h1>
+<%= h1 "Assessing Gillick competence", class: "nhsuk-heading-l" %>
 
 <p>Can the young person tell you:</p>
 

--- a/app/views/consents/edit_confirm.html.erb
+++ b/app/views/consents/edit_confirm.html.erb
@@ -9,7 +9,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Check and confirm answers</h1>
+<%= h1 "Check and confirm answers", class: "nhsuk-heading-l" %>
 
 <% if @draft_consent.via_self_consent? %>
   <%= render AppGillickCardComponent.new(

--- a/app/views/consents/edit_consent.html.erb
+++ b/app/views/consents/edit_consent.html.erb
@@ -7,6 +7,8 @@
   ) %>
 <% end %>
 
+<% content_for :page_title, "Do they agree to them having the HPV vaccination?" %>
+
 <%= form_for @draft_consent,
   url: session_patient_consents_path(@session, @patient),
   method: :put do |f| %>

--- a/app/views/consents/edit_gillick.html.erb
+++ b/app/views/consents/edit_gillick.html.erb
@@ -5,6 +5,8 @@
   ) %>
 <% end %>
 
+<% content_for :page_title, "Are they Gillick competent?" %>
+
 <%= form_for @patient_session,
   url: update_gillick_session_patient_consents_path(@session, @patient),
   method: :put do |f| %>

--- a/app/views/consents/edit_questions.html.erb
+++ b/app/views/consents/edit_questions.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Health questions</h1>
+<%= h1 "Health questions", class: "nhsuk-heading-l" %>
 
 <%= form_for @draft_consent,
   url: session_patient_consents_path(@session, @patient),

--- a/app/views/consents/edit_reason.html.erb
+++ b/app/views/consents/edit_reason.html.erb
@@ -5,6 +5,8 @@
   ) %>
 <% end %>
 
+<% content_for :page_title, "Why do they not agree?" %>
+
 <%= form_for @draft_consent,
   url: session_patient_consents_path(@session, @patient),
   method: :put do |f| %>

--- a/app/views/consents/edit_who.html.erb
+++ b/app/views/consents/edit_who.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Who are you trying to get consent from?</h1>
+<%= h1 "Who are you trying to get consent from?", class: "nhsuk-heading-l" %>
 
 <%= form_for @draft_consent,
   url: session_patient_consents_path(@session, @patient),

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,6 +1,4 @@
-<%= content_for :page_title, "Sorry, there’s a problem with the service" %>
-
-<h1 class="nhsuk-heading-l">Sorry, there’s a problem with the service</h1>
+<%= h1 "Sorry, there’s a problem with the service", class: "nhsuk-heading-l" %>
 
 <p class="nhsuk-body">Try again later.</p>
 

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,6 +1,5 @@
-<%= content_for :page_title, "Page not found" %>
+<%= h1 "Page not found", class: "nhsuk-heading-l" %>
 
-<h1 class="nhsuk-heading-l">Page not found</h1>
 <p class="nhsuk-body">
   If you entered a web address, check it is correct.
 </p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,6 +1,4 @@
-<%= content_for :page_title, 'Sorry, there’s a problem with the service' %>
-
-<h1 class="nhsuk-heading-l">Sorry, there’s a problem with the service</h1>
+<%= h1 "Sorry, there’s a problem with the service", class: "nhsuk-heading-l" %>
 
 <p class="nhsuk-body">Try again later.</p>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="nhsuk-template">
   <head>
     <meta charset="utf-8">
-    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
+    <title><%= page_title %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/offline_passwords/new.html.erb
+++ b/app/views/offline_passwords/new.html.erb
@@ -3,9 +3,8 @@
     <%= form_with(model: @password, url: setup_offline_session_path) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="nhsuk-heading-l">
-        Create a password to protect your offline changes
-      </h1>
+      <%= h1 "Create a password to protect your offline changes",
+        class: "nhsuk-heading-l" %>
 
       <p>
         Before you can work offline, you need to create a password. We'll use

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,6 +1,6 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <h1><%= t('service.name') %></h1>
+    <%= h1 t('service.name') %>
 
     <p>Use this service to:</p>
 

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -8,7 +8,7 @@
   ]) %>
 <% end %>
 
-<h1>School sessions</h1>
+<%= h1 "School sessions" %>
 
 <% @sessions_by_type.each do |campaign_type, sessions| %>
   <h2><%= campaign_type %></h2>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -5,12 +5,12 @@
   ]) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">
+<%= h1 page_title: @session.name, class: "nhsuk-heading-l" do %>
   <%= @session.name %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @session.date.to_fs(:long_ordinal_uk) %>
   </span>
-</h1>
+<% end %>
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -10,7 +10,7 @@
   ]) %>
 <% end %>
 
-<h1>Triage</h1>
+<%= h1 "Triage" %>
 
 <%=
 govuk_tabs title: "Patient triage", classes: 'nhsuk-tabs' do |c|

--- a/app/views/triage/show.html.erb
+++ b/app/views/triage/show.html.erb
@@ -9,9 +9,7 @@
              ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l" id="<%= dom_id @patient %>">
-  <%= @patient.full_name %>
-</h1>
+<%= h1 @patient.full_name, id: dom_id(@patient), class: "nhsuk-heading-l" %>
 
 <%= render AppStatusBannerComponent.new(patient_session: @patient_session) %>
 

--- a/app/views/vaccinations/batches/edit.html.erb
+++ b/app/views/vaccinations/batches/edit.html.erb
@@ -5,6 +5,8 @@
   ) %>
 <% end %>
 
+<% content_for :page_title, "Which batch did you use?" %>
+
 <%= form_with model: @draft_vaccination_record,
    url: session_patient_vaccinations_batch_path(
        session_id: @session.id,

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -12,7 +12,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Check and confirm</h1>
+<%= h1 "Check and confirm", class: "nhsuk-heading-l" %>
 
 <div class="nhsuk-card">
   <div class="nhsuk-card__content">

--- a/app/views/vaccinations/delivery_site/edit.html.erb
+++ b/app/views/vaccinations/delivery_site/edit.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l">Tell us how the vaccination was given</h1>
+<%= h1 "Tell us how the vaccination was given", class: "nhsuk-heading-l" %>
 
 <%= form_with model: @draft_vaccination_record,
    url: session_patient_vaccinations_delivery_site_path(

--- a/app/views/vaccinations/edit_reason.html.erb
+++ b/app/views/vaccinations/edit_reason.html.erb
@@ -5,6 +5,8 @@
              ) %>
 <% end %>
 
+<% content_for :page_title, "Why was the HPV vaccine not given?" %>
+
 <%= form_with model: @draft_vaccination_record,
               url: session_patient_vaccinations_path(
                 session_id: @session.id,
@@ -12,7 +14,8 @@
               ),
               method: :put do |f| %>
     <%= f.govuk_radio_buttons_fieldset(:reason,
-      legend: { size: 'l', text: 'Why was the HPV vaccine not given?' }) do %>
+      legend: { size: 'l', tag: 'h1',
+                text: 'Why was the HPV vaccine not given?' }) do %>
 
       <%= f.govuk_radio_button :reason, "refused",
         label: { text: 'They refused it' } %>

--- a/app/views/vaccinations/history.html.erb
+++ b/app/views/vaccinations/history.html.erb
@@ -1,8 +1,6 @@
 <%= link_to "Back", session_patient_vaccinations_path(@session, @patient) %>
 
-<h1 class="nhsuk-u-heading-xl">
-  Vaccination record
-</h1>
+<%= h1 "Vaccination record" %>
 
 <% @history.each do |entry| %>
   <h3 class="nhsuk-heading-m">

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -10,7 +10,7 @@
   ]) %>
 <% end %>
 
-<h1>Record vaccinations</h1>
+<%= h1 "Record vaccinations" %>
 
 <%=
 govuk_tabs title: "Vaccinations", classes: 'nhsuk-tabs' do |c|

--- a/app/views/vaccinations/new.html.erb
+++ b/app/views/vaccinations/new.html.erb
@@ -5,4 +5,6 @@
              ) %>
 <% end %>
 
+<% content_for :page_title, "Did they get the vaccine?" %>
+
 <%= render "form", embedded: false %>

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -9,9 +9,7 @@
              ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l" id="<%= dom_id @patient %>">
-  <%= @patient.full_name %>
-</h1>
+<%= h1 @patient.full_name, id: dom_id(@patient), class: "nhsuk-heading-l" %>
 
 <%= render AppStatusBannerComponent.new(patient_session: @patient_session) %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "#h1" do
+    context "when called with only text" do
+      it "returns an h1 tag with the text" do
+        expect(helper.h1("Title")).to eq("<h1>Title</h1>")
+      end
+
+      it "sets the page title" do
+        helper.h1("Title")
+        expect(helper.content_for(:page_title)).to eq("Title")
+      end
+    end
+
+    context "when called with text and page_title option" do
+      it "returns an h1 tag with the text" do
+        expect(helper.h1("Title", page_title: "Custom")).to eq("<h1>Title</h1>")
+      end
+
+      it "sets the page title from the option" do
+        helper.h1("Title", page_title: "Custom")
+        expect(helper.content_for(:page_title)).to eq("Custom")
+      end
+    end
+
+    context "when called with a block" do
+      it "raises an error if the title option is not provided" do
+        expect { helper.h1 { "Title" } }.to raise_error(ArgumentError)
+      end
+
+      it "returns an h1 tag with the block content" do
+        output = helper.h1(page_title: "Custom Title") { "Block Content" }
+        expect(output).to eq("<h1>Block Content</h1>")
+      end
+
+      it "sets the page title from the title option" do
+        helper.h1(page_title: "Custom Title") { "Block Content" }
+        expect(helper.content_for(:page_title)).to eq("Custom Title")
+      end
+    end
+
+    context "when page title is already set" do
+      before { helper.content_for(:page_title, "Existing Title") }
+
+      it "does not override the existing page title" do
+        helper.h1("New Title")
+        expect(helper.content_for(:page_title)).to eq("Existing Title")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces a h1 helper that automatically sets `content_for(:page_title)`. Currently none of our pages have custom titles, which is an accessibility issue. Every page must also have one (and preferably only one) h1 element, and in most cases the content of the custom title prefix and the h1 will coincide.

TODO:

- [x] Investigate automatically setting an `Error:` prefix when the page status is a 422
- [x] Update every template to use the h1 helper
  - [x] For the pages with simple forms that use an h1 as the legend, set the page_title using the manual way