### PR TITLE
Override service name in consent journeys

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
+  before_action :set_service_name
 
   class UnprocessableEntity < StandardError
   end
@@ -18,6 +19,10 @@ class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   private
+
+  def set_service_name
+    @service_name = "Manage vaccinations for school-aged children"
+  end
 
   def set_disable_cache_headers
     response.headers["Cache-Control"] = "no-store"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
+  before_action :set_header_path
   before_action :set_service_name
 
   class UnprocessableEntity < StandardError
@@ -19,6 +20,10 @@ class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   private
+
+  def set_header_path
+    @header_path = dashboard_path
+  end
 
   def set_service_name
     @service_name = "Manage vaccinations for school-aged children"

--- a/app/controllers/consent_forms/base_controller.rb
+++ b/app/controllers/consent_forms/base_controller.rb
@@ -1,6 +1,10 @@
 class ConsentForms::BaseController < ApplicationController
   private
 
+  def set_header_path
+    @header_path = start_session_consent_forms_path
+  end
+
   def set_service_name
     @service_name = "Give or refuse consent for vaccinations"
   end

--- a/app/controllers/consent_forms/base_controller.rb
+++ b/app/controllers/consent_forms/base_controller.rb
@@ -1,0 +1,7 @@
+class ConsentForms::BaseController < ApplicationController
+  private
+
+  def set_service_name
+    @service_name = "Give or refuse consent for vaccinations"
+  end
+end

--- a/app/controllers/consent_forms/name_controller.rb
+++ b/app/controllers/consent_forms/name_controller.rb
@@ -1,4 +1,4 @@
-class ConsentForms::NameController < ApplicationController
+class ConsentForms::NameController < ConsentForms::BaseController
   before_action :set_session, only: %i[edit update]
   before_action :set_consent_form, only: %i[edit update]
 

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -1,4 +1,4 @@
-class ConsentFormsController < ApplicationController
+class ConsentFormsController < ConsentForms::BaseController
   layout "two_thirds"
 
   before_action :set_session

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
     end
   end
 
-  def page_title
+  def page_title(service_name)
     title = content_for(:page_title)
 
     if title.blank?
@@ -25,6 +25,6 @@ or set it with content_for(:page_title)."
 
     title = "Error: #{title}" if response.status == 422
 
-    [title, t("service.name")].join(" - ")
+    [title, service_name].join(" - ")
   end
 end

--- a/app/views/consent_forms/name/edit.html.erb
+++ b/app/views/consent_forms/name/edit.html.erb
@@ -25,7 +25,7 @@
       <%= f.govuk_text_field :common_name, label: { text: 'Known as' } %>
     <% end %>
     <%= f.govuk_radio_button :use_common_name, false, label: { text: 'No' } %>
-  <% end %%>
+  <% end %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -8,7 +8,7 @@
 </p>
 <p class="nhsuk-body">
   If the web address is correct or you selected a link or button and you
-  need to speak to someone about this problem, contact the <%= t('service.name') %>
+  need to speak to someone about this problem, contact the <%= @service_name %>
   team: <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
   <%= t('service.email') %></a>.
 </p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -3,7 +3,7 @@
 <p class="nhsuk-body">Try again later.</p>
 
 <p class="nhsuk-body">
-  If you continue to see this error contact the <%= t('service.name') %>
+  If you continue to see this error contact the <%= @service_name %>
   team: <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
   <%= t('service.email') %></a>.
 </p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="nhsuk-template">
   <head>
     <meta charset="utf-8">
-    <title><%= page_title %></title>
+    <title><%= page_title(@service_name) %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -28,7 +28,7 @@
               <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
             </svg>
             <span class="nhsuk-header__service-name">
-              <%= t('service.name') %>
+              <%= @service_name %>
             </span>
           </a>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,9 @@
     <header class="nhsuk-header" role="banner">
       <div class="nhsuk-width-container nhsuk-header__container">
         <div class="nhsuk-header__logo nhsuk-header__logo--only">
-          <a class="nhsuk-header__link nhsuk-header__link--service" href="/dashboard" aria-label="NHS homepage">
+          <a class="nhsuk-header__link nhsuk-header__link--service"
+             href="<%= @header_path %>"
+             aria-label="Service homepage">
             <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
               <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
               <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,6 +1,6 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <%= h1 t('service.name') %>
+    <%= h1 @service_name %>
 
     <p>Use this service to:</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,5 @@
 en:
   service:
-    name: Manage vaccinations for school-aged children
     email: my-service@email
   activerecord:
     attributes:


### PR DESCRIPTION
This changes from using the `t('service.name')` translation string to a `@service_name` instance variable that's set by `ApplicationController` and can be overridden by other controllers that inherit from it.

It introduces a new `ConsentForms::BaseController` that can be used for this purpose.

This PR also includes a couple of other small tweaks, see commits.