### PR TITLE
Add DateParamsValidator for date_of_birth

### DIFF
--- a/app/controllers/consent_forms/edit_controller.rb
+++ b/app/controllers/consent_forms/edit_controller.rb
@@ -8,6 +8,7 @@ class ConsentForms::EditController < ConsentForms::BaseController
 
   before_action :set_session
   before_action :set_consent_form
+  before_action :validate_params, only: %i[update]
 
   def show
     render_wizard
@@ -67,5 +68,22 @@ class ConsentForms::EditController < ConsentForms::BaseController
 
   def set_consent_form
     @consent_form = ConsentForm.find(params.fetch(:consent_form_id))
+  end
+
+  def validate_params
+    case current_step
+    when :date_of_birth
+      validator =
+        DateParamsValidator.new(
+          field_name: :date_of_birth,
+          object: @consent_form,
+          params: date_of_birth_params
+        )
+
+      unless validator.date_params_valid?
+        @consent_form.date_of_birth = validator.date_params_as_struct
+        render_wizard nil, status: :unprocessable_entity
+      end
+    end
   end
 end

--- a/app/lib/date_params_validator.rb
+++ b/app/lib/date_params_validator.rb
@@ -1,0 +1,43 @@
+class DateParamsValidator
+  attr_reader :field_name, :object, :params
+
+  def initialize(field_name:, object:, params:)
+    @field_name = field_name
+    @object = object
+    @params = params
+  end
+
+  def date_params_as_struct
+    date_params = [
+      params["#{field_name}(1i)"],
+      params["#{field_name}(2i)"],
+      params["#{field_name}(3i)"]
+    ]
+    Struct.new(:year, :month, :day).new(*date_params)
+  end
+
+  def date_params_valid?
+    date = date_params_as_struct
+
+    # Let the model decide if this is valid
+    return true if [date.year, date.month, date.day].all?(&:blank?)
+
+    if date.day.blank?
+      object.errors.add(field_name, :missing_day)
+    elsif date.month.blank?
+      object.errors.add(field_name, :missing_month)
+    elsif date.year.blank?
+      object.errors.add(field_name, :missing_year)
+    elsif date.year.to_i < 1000
+      object.errors.add(field_name, :missing_year)
+    else
+      begin
+        Date.new(date.year.to_i, date.month.to_i, date.day.to_i)
+      rescue Date::Error
+        object.errors.add(field_name, :blank)
+      end
+    end
+
+    object.errors.none?
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,10 +85,13 @@ en:
         consent_form:
           attributes:
             date_of_birth:
-              blank: Enter a date
+              blank: Enter their date of birth
               greater_than_or_equal_to: The child cannot be older than 22. Enter a date after %{count}.
               less_than: The date is in the future. Enter a date in the past.
               less_than_or_equal_to: The child cannot be younger than 3. Enter a date after %{count}.
+              missing_year: Enter a year
+              missing_month: Enter a month
+              missing_day: Enter a day
             common_name:
               blank: Enter a name
             first_name:

--- a/spec/lib/date_params_validator_spec.rb
+++ b/spec/lib/date_params_validator_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+require "date"
+
+RSpec.describe DateParamsValidator do
+  let(:dummy_class) do
+    Class.new do
+      attr_accessor :errors
+
+      # Cannot find a better way to get the errors for a specific attribute,
+      # replace as appropriate.
+      def errors_for_attribute(attribute)
+        errors.find_all { |e| e.attribute == attribute }.map(&:type)
+      end
+    end
+  end
+
+  let(:dummy_object) do
+    dummy_class.new.tap { |obj| obj.errors = ActiveModel::Errors.new(obj) }
+  end
+  let(:field_name) { "date_of_birth" }
+  let(:params) { {} }
+  let(:validator) do
+    described_class.new(field_name:, object: dummy_object, params:)
+  end
+
+  let(:year) { "2012" }
+  let(:month) { "12" }
+  let(:day) { "24" }
+
+  let(:params) do
+    {
+      "date_of_birth(1i)" => year,
+      "date_of_birth(2i)" => month,
+      "date_of_birth(3i)" => day
+    }
+  end
+
+  describe "#date_params_as_struct" do
+    context "when date params are provided" do
+      let(:year) { "2000" }
+      let(:month) { "1" }
+      let(:day) { "20" }
+
+      it "returns a struct with year, month, and day" do
+        struct = validator.date_params_as_struct
+
+        expect(struct.year).to eq("2000")
+        expect(struct.month).to eq("1")
+        expect(struct.day).to eq("20")
+      end
+    end
+  end
+
+  describe "#date_params_valid?" do
+    context "with a valid date regardless of the model validations" do
+      let(:year) { "1972" }
+      let(:month) { "4" }
+      let(:day) { "3" }
+
+      it "returns true" do
+        expect(validator.date_params_valid?).to be true
+      end
+    end
+
+    context "when all date params are blank" do
+      let(:year) { "" }
+      let(:month) { "" }
+      let(:day) { "" }
+
+      it "returns true" do
+        expect(validator.date_params_valid?).to be true
+      end
+    end
+
+    context "when day is missing" do
+      let(:year) { "2000" }
+      let(:month) { "1" }
+      let(:day) { "" }
+
+      it "adds a missing_day error and returns false" do
+        expect(validator.date_params_valid?).to be false
+        expect(dummy_object.errors_for_attribute(:date_of_birth)).to include(
+          :missing_day
+        )
+      end
+    end
+
+    context "when month is missing" do
+      let(:year) { "2000" }
+      let(:month) { "" }
+      let(:day) { "20" }
+
+      it "adds a missing_month error and returns false" do
+        expect(validator.date_params_valid?).to be false
+        expect(dummy_object.errors_for_attribute(:date_of_birth)).to include(
+          :missing_month
+        )
+      end
+    end
+
+    context "when year is missing" do
+      let(:year) { "" }
+      let(:month) { "1" }
+      let(:day) { "20" }
+
+      it "adds a missing_year error and returns false" do
+        expect(validator.date_params_valid?).to be false
+        expect(dummy_object.errors_for_attribute(:date_of_birth)).to include(
+          :missing_year
+        )
+      end
+    end
+
+    context "when year is less than 1000" do
+      let(:year) { "860" }
+      let(:month) { "1" }
+      let(:day) { "20" }
+
+      it "adds a missing_year error and returns false" do
+        expect(validator.date_params_valid?).to be false
+        expect(dummy_object.errors_for_attribute(:date_of_birth)).to include(
+          :missing_year
+        )
+      end
+    end
+
+    context "when date is invalid" do
+      let(:year) { "2000" }
+      let(:month) { "2" }
+      let(:day) { "30" }
+
+      it "adds a blank error and returns false" do
+        expect(validator.date_params_valid?).to be false
+        expect(dummy_object.errors_for_attribute(:date_of_birth)).to include(
+          :blank
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The approach is taken partially from DfE's FindALostTRN, slightly tweaked here as we don't have form objects and want to reuse model validations.

In this approach we only validate the form inputs, but not the actual parameters required by the date of birth attribute on consent forms. This should make this library usable on other models.