### PR TITLE
Define steps in ConsentForm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,5 +59,6 @@ group :test do
   gem "capybara"
   gem "cuprite"
   gem "rspec"
+  gem "shoulda-matchers"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,6 +472,8 @@ GEM
       sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     silencer (2.0.0)
     solargraph (0.49.0)
       backport (~> 1.2)
@@ -586,6 +588,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-rails
   sentry-ruby
+  shoulda-matchers
   silencer
   solargraph
   solargraph-rails

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -8,7 +8,8 @@ class ConsentFormsController < ConsentForms::BaseController
   end
 
   def create
-    consent_form = @session.consent_forms.create!
+    consent_form = @session.consent_forms.new
+    consent_form.save!(validate: false)
     redirect_to session_consent_form_edit_path(@session, consent_form, :name)
   end
 

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -8,8 +8,7 @@ class ConsentFormsController < ConsentForms::BaseController
   end
 
   def create
-    consent_form = @session.consent_forms.new
-    consent_form.save!(validate: false)
+    consent_form = @session.consent_forms.create!
     redirect_to session_consent_form_edit_path(@session, consent_form, :name)
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -33,29 +33,31 @@ class ConsentForm < ApplicationRecord
 
   belongs_to :session
 
-  with_options if: -> { required_for_step?(:name) } do
-    validates :first_name, presence: true
-    validates :last_name, presence: true
-    validates :use_common_name, inclusion: { in: [true, false] }
-    validates :common_name, presence: true, if: :use_common_name?
-  end
+  with_options on: :update do
+    with_options if: -> { required_for_step?(:name) } do
+      validates :first_name, presence: true
+      validates :last_name, presence: true
+      validates :use_common_name, inclusion: { in: [true, false] }
+      validates :common_name, presence: true, if: :use_common_name?
+    end
 
-  with_options if: -> { required_for_step?(:date_of_birth) } do
-    validates :date_of_birth,
-              presence: true,
-              comparison: {
-                less_than: Time.zone.today,
-                greater_than_or_equal_to: 22.years.ago.to_date,
-                less_than_or_equal_to: 3.years.ago.to_date
-              }
-  end
+    with_options if: -> { required_for_step?(:date_of_birth) } do
+      validates :date_of_birth,
+                presence: true,
+                comparison: {
+                  less_than: Time.zone.today,
+                  greater_than_or_equal_to: 22.years.ago.to_date,
+                  less_than_or_equal_to: 3.years.ago.to_date
+                }
+    end
 
-  with_options if: -> { required_for_step?(:school, exact: true) } do
-    validates :is_this_their_school,
-              presence: true,
-              inclusion: {
-                in: %w[yes no]
-              }
+    with_options if: -> { required_for_step?(:school, exact: true) } do
+      validates :is_this_their_school,
+                presence: true,
+                inclusion: {
+                  in: %w[yes no]
+                }
+    end
   end
 
   def full_name

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :consent_form do
+  end
+end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe ConsentForm, type: :model do
+  describe "Validations" do
+    let(:form_step) { nil }
+    let(:use_common_name) { false }
+    subject { build(:consent_form, form_step:, use_common_name:) }
+
+    it "validates all fields when no form_step is set" do
+      expect(subject).to validate_presence_of(:first_name).on(:update)
+      expect(subject).to validate_presence_of(:last_name).on(:update)
+      expect(subject).to validate_presence_of(:date_of_birth).on(:update)
+    end
+
+    context "when form_step is :name" do
+      let(:form_step) { :name }
+
+      it { should validate_presence_of(:first_name).on(:update) }
+      it { should validate_presence_of(:last_name).on(:update) }
+
+      context "when use_common_name is true" do
+        let(:use_common_name) { true }
+
+        it { should validate_presence_of(:common_name).on(:update) }
+      end
+    end
+
+    context "when form_step is :date_of_birth" do
+      let(:form_step) { :date_of_birth }
+
+      context "runs validations from previous steps" do
+        it { should validate_presence_of(:first_name).on(:update) }
+      end
+
+      it { should validate_presence_of(:date_of_birth).on(:update) }
+      # it { should validate_comparison_of(:date_of_birth)
+      #       .is_less_than(Time.zone.today)
+      #       .is_greater_than_or_equal_to(22.years.ago.to_date)
+      #       .is_less_than_or_equal_to(3.years.ago.to_date)
+      #       .on(:update) }
+    end
+
+    context "when form_step is :school" do
+      let(:form_step) { :school }
+
+      context "runs validations from previous steps" do
+        it { should validate_presence_of(:first_name).on(:update) }
+        it { should validate_presence_of(:date_of_birth).on(:update) }
+      end
+
+      it { should validate_presence_of(:is_this_their_school).on(:update) }
+      it do
+        should validate_inclusion_of(:is_this_their_school).in_array(
+                 %w[yes no]
+               ).on(:update)
+      end
+    end
+  end
+
+  describe "#full_name" do
+    it "returns the full name as a string" do
+      consent_form = build(:consent_form, first_name: "John", last_name: "Doe")
+      expect(consent_form.full_name).to eq("John Doe")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,13 @@ Capybara.register_driver(:cuprite_custom) do |app|
 end
 Capybara.javascript_driver = :cuprite_custom
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Replace the `on:` context based validation with conditional validation that relies on specifying a `form_step`. This also makes the validations fire off for previous steps, and at the end for the final `record` step.

Unifies the `*_params` methods in the EditController into one `update_params` method.

`required_for_step?` takes an optional `exact` parameter, for transient steps like the `school` one that ask a question but don't actually save a field to the database (and shouldn't be re-validated on other steps).

Overall approach based on:
https://www.joshmcarthur.com/2014/12/23/rails-multistep-forms.html