### PR TITLE
Move contact method to separate page

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -26,11 +26,6 @@ $color_app-pale-blue: #ccdff1;
 @import "_empty-list.scss";
 @import "_offline.sass.scss";
 
-.app-u-frutiger,
-.app-u-frutiger * {
-  font-family: "Frutiger W01", Arial, sans-serif !important;
-}
-
 .app-summary-list--no-bottom-border {
   .govuk-summary-list__row:last-child {
     border-bottom: none;

--- a/app/controllers/consent_forms/edit_controller.rb
+++ b/app/controllers/consent_forms/edit_controller.rb
@@ -56,9 +56,8 @@ class ConsentForms::EditController < ConsentForms::BaseController
         parent_relationship_other
         parent_email
         parent_phone
-        contact_method
-        contact_method_other
       ],
+      contact_method: %i[contact_method contact_method_other],
       consent: %i[response],
       reason: %i[reason reason_notes],
       injection: %i[contact_injection]

--- a/app/helpers/consent_forms_helper.rb
+++ b/app/helpers/consent_forms_helper.rb
@@ -1,0 +1,11 @@
+module ConsentFormsHelper
+  def contact_method_for(consent_form)
+    text = consent_form.human_enum_name(:contact_method)
+
+    if consent_form.contact_method_other?
+      "#{text} – #{consent_form.contact_method_other}"
+    else
+      text
+    end
+  end
+end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -114,13 +114,11 @@ class ConsentForm < ApplicationRecord
   end
 
   def form_steps
-    if consent_refused? && eligible_for_injection?
-      %i[name date_of_birth school parent consent reason injection]
-    elsif consent_refused?
-      %i[name date_of_birth school parent consent reason]
-    else
-      %i[name date_of_birth school parent consent]
-    end
+    steps = %i[name date_of_birth school parent]
+    steps += %i[consent]
+    steps += %i[reason] if consent_refused?
+    steps += %i[injection] if consent_refused? && eligible_for_injection?
+    steps
   end
 
   private

--- a/app/views/consent_forms/confirm.html.erb
+++ b/app/views/consent_forms/confirm.html.erb
@@ -102,11 +102,19 @@
 
       if @consent_form.parent_phone.present?
         summary_list.with_row do |row|
-          row.with_key { "Phone number" }
+          row.with_key { "Telephone number" }
           row.with_value { @consent_form.parent_phone }
           row.with_action(text: "Change",
             href: session_consent_form_edit_path(@session, @consent_form, :parent),
             visually_hidden_text: "your phone")
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Telephone contact method" }
+          row.with_value { contact_method_for(@consent_form) }
+          row.with_action(text: "Change",
+            href: session_consent_form_edit_path(@session, @consent_form, :parent),
+            visually_hidden_text: "your phone contact method")
         end
       end
     end %>

--- a/app/views/consent_forms/edit/contact_method.html.erb
+++ b/app/views/consent_forms/edit/contact_method.html.erb
@@ -1,0 +1,36 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+      href: previous_wizard_path,
+      name: "previous page"
+  ) %>
+<% end %>
+
+<% title "Telephone contact method" %>
+<% content_for :page_title, title %>
+
+<%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_radio_buttons_fieldset(:contact_method,
+    legend: { size: 'l', text: 'Telephone contact method', tag: 'h1' },
+    hint: { text: "Tell us if you have specific needs" }
+  ) do %>
+    <%= f.govuk_radio_button :contact_method, "text",
+      label: { text: 'I can only receive text messages' },
+      link_errors: true %>
+    <%= f.govuk_radio_button :contact_method, "voice",
+      label: { text: 'I can only receive voice calls' } %>
+    <%= f.govuk_radio_button :contact_method, "other",
+      label: { text: 'Other' } do %>
+      <%= f.govuk_text_area :contact_method_other,
+        label: { text: 'Give details' } %>
+    <% end %>
+    <%= f.govuk_radio_divider %>
+    <%= f.govuk_radio_button :contact_method, "any",
+      label: { text: 'I do not have specific needs' } %>
+  <% end %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
+<% end %>

--- a/app/views/consent_forms/edit/parent.html.erb
+++ b/app/views/consent_forms/edit/parent.html.erb
@@ -40,24 +40,6 @@
     label: { text: 'Telephone number (optional)' },
     hint: { text: 'A nurse might call you about your child’s vaccination' } %>
 
-  <%= govuk_details(
-    summary_text: "I need to tell you more about how to contact me",
-    open: @consent_form.contact_method.present?) do %>
-    <%= f.govuk_radio_buttons_fieldset(:contact_method,
-      legend: { size: 's',
-                text: 'Do you need any of the following?' }) do %>
-      <%= f.govuk_radio_button :contact_method, "text",
-        label: { text: 'Text only (no voice calls)' }, link_errors: true %>
-      <%= f.govuk_radio_button :contact_method, "voice",
-        label: { text: "Voice only (no text)" } %>
-      <%= f.govuk_radio_button :contact_method, "other",
-        label: { text: 'Other' } do %>
-        <%= f.govuk_text_area :contact_method_other,
-          label: { text: 'Give details' } %>
-      <% end %>
-    <% end %>
-  <% end %>
-
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>
   </div>

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -63,7 +63,7 @@
       <h2 class="nhsuk-card__heading nhsuk-heading-m">
         Vaccination details
       </h2>
-      <dl class="nhsuk-summary-list app-u-frutiger app-summary-list--no-bottom-border  nhsuk-u-margin-bottom-0">
+      <dl class="nhsuk-summary-list app-summary-list--no-bottom-border  nhsuk-u-margin-bottom-0">
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
             Vaccine

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
     consent: "consent"
     reason: "reason"
     injection: "injection"
+    contact_method: "contact-method"
   activerecord:
     attributes:
       consent:

--- a/spec/components/app_flash_message_component_spec.rb
+++ b/spec/components/app_flash_message_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AppFlashMessageComponent, type: :component do
   context "when no flash message is provided" do
     let(:flash) { {} }
 
-    it { should have_text(nil) }
+    it { should have_text("", exact: true) }
   end
 
   describe "the render? method" do
@@ -32,7 +32,7 @@ RSpec.describe AppFlashMessageComponent, type: :component do
   context "when an unknown flash key is provided" do
     let(:flash) { { unknown: "Message" } }
 
-    it { should have_text(nil) }
+    it { should have_text("", exact: true) }
   end
 
   context "when a simple string is provided" do

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -186,6 +186,11 @@ RSpec.describe ConsentForm, type: :model do
   end
 
   describe "#form_steps" do
+    it "asks for contact method if phone is specified" do
+      consent_form = build(:consent_form, parent_phone: "0123456789")
+      expect(consent_form.form_steps).to include(:contact_method)
+    end
+
     it "does not ask for reason when patient gives consent" do
       consent_form = build(:consent_form, response: "given")
       expect(consent_form.form_steps).not_to include(:reason)

--- a/tests/parental_consent.spec.ts
+++ b/tests/parental_consent.spec.ts
@@ -26,6 +26,10 @@ test("Parental consent", async ({ page }) => {
 
   await when_i_enter_the_parent_details();
   await and_i_click_continue();
+  await then_i_see_the_phone_contact_page();
+
+  await when_i_enter_the_phone_contact_details();
+  await and_i_click_continue();
   await then_i_see_the_consent_page();
 
   await when_i_fill_in_the_consent_form();
@@ -122,4 +126,12 @@ async function then_i_see_the_consent_page() {
 
 async function when_i_fill_in_the_consent_form() {
   await p.getByText("Yes, I agree to them having a nasal vaccine").click();
+}
+
+async function then_i_see_the_phone_contact_page() {
+  await expect(p.locator("h1")).toContainText("Telephone contact method");
+}
+
+async function when_i_enter_the_phone_contact_details() {
+  await p.getByRole("radio", { name: "I do not have specific needs" }).click();
 }

--- a/tests/parental_consent_refused.spec.ts
+++ b/tests/parental_consent_refused.spec.ts
@@ -51,7 +51,6 @@ async function when_i_go_through_the_consent_journey() {
   await p.getByLabel("Your name").fill("Joe Senior");
   await p.getByRole("radio", { name: "Dad" }).click();
   await p.getByLabel("Email address").fill("joe.senior@example.com");
-  await p.getByLabel("Telephone number").fill("07123456789");
   await and_i_click_continue();
 }
 


### PR DESCRIPTION
Follows the new design in the prototype, allowing users to specify that there is no preferred contact method they need, unlike the old design.

See commits, first is unrelated to this work, but too small to PR on its own.

See https://github.com/nhsuk/consent-for-vaccinations-prototype/pull/97

### New page

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/c88669b9-f015-4a2c-8ffe-f018f9e2ae5b)

### Confirmation page

![image](https://github.com/nhsuk/record-childrens-vaccinations/assets/1650875/18b1983d-7908-42c2-88f7-80589dfc5cea)
