### PR TITLE
Allow users to answer "No" when refusing contact for an injection

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -126,7 +126,7 @@ class ConsentForm < ApplicationRecord
     end
 
     with_options if: -> { required_for_step?(:injection) } do
-      validates :contact_injection, presence: true
+      validates :contact_injection, inclusion: { in: [true, false] }
     end
 
     with_options if: -> { required_for_step?(:gp) } do

--- a/app/views/consent_forms/edit/injection.html.erb
+++ b/app/views/consent_forms/edit/injection.html.erb
@@ -16,7 +16,7 @@
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset(:response,
+  <%= f.govuk_radio_buttons_fieldset(:contact_injection,
     legend: { size: 's',
               text: 'Would you like a nurse to contact you about this option?' }
   ) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,7 +154,7 @@ en:
             reason:
               blank: Choose a reason
             contact_injection:
-              blank: Choose if you want to be contacted
+              inclusion: Choose if you want to be contacted
             gp_response:
               blank: Choose if your child is registered with a GP
             gp_name:

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -183,7 +183,13 @@ RSpec.describe ConsentForm, type: :model do
         it { should validate_presence_of(:reason).on(:update) }
       end
 
-      it { should validate_presence_of(:contact_injection).on(:update) }
+      # This prints a warning because boolean fields always get converted to
+      # false when they are blank. As such we can't check for this validation.
+      # it do
+      #   should validate_inclusion_of(:contact_injection).in_array(
+      #            [true, false]
+      #          ).on(:update)
+      # end
     end
 
     context "when form_step is :gp" do

--- a/tests/parental_consent_refused.spec.ts
+++ b/tests/parental_consent_refused.spec.ts
@@ -17,7 +17,7 @@ test("Parental consent - Consent refused", async ({ page }) => {
   await and_i_click_continue();
   await then_i_see_the_injection_page();
 
-  await when_i_choose_to_have_the_injection();
+  await when_i_choose_to_not_have_the_injection();
   await and_i_click_continue();
   await then_i_see_the_consent_confirm_page();
 });
@@ -88,6 +88,6 @@ async function then_i_see_the_injection_page() {
   );
 }
 
-async function when_i_choose_to_have_the_injection() {
-  await p.click("text=Yes, I am happy for a nurse to contact me");
+async function when_i_choose_to_not_have_the_injection() {
+  await p.getByRole("radio", { name: "No" }).click();
 }


### PR DESCRIPTION
`presence: true` makes the "false" option the same as selecting nothing at all. `inclusion` works better.