### PR TITLE
Skip to confirmation page if param is set

### DIFF
--- a/app/controllers/consent_forms/edit_controller.rb
+++ b/app/controllers/consent_forms/edit_controller.rb
@@ -42,6 +42,8 @@ class ConsentForms::EditController < ConsentForms::BaseController
       )
     end
 
+    return redirect_to finish_wizard_path if skip_to_confirm?
+
     render_wizard @consent_form
   end
 
@@ -118,5 +120,9 @@ class ConsentForms::EditController < ConsentForms::BaseController
   def current_health_answer
     index = step.split("-").last.to_i - 1
     @consent_form.health_answers[index]
+  end
+
+  def skip_to_confirm?
+    request.referer.include?("skip_to_confirm")
   end
 end

--- a/app/views/consent_forms/confirm.html.erb
+++ b/app/views/consent_forms/confirm.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% change_link = Proc.new do |attr|
-  options = {}
+  options = attr.in?(%i[consent reason]) ? {} : { skip_to_confirm: true }
   session_consent_form_edit_path(
     @session,
     @consent_form,

--- a/app/views/consent_forms/confirm.html.erb
+++ b/app/views/consent_forms/confirm.html.erb
@@ -5,6 +5,16 @@
   ) %>
 <% end %>
 
+<% change_link = Proc.new do |attr|
+  options = {}
+  session_consent_form_edit_path(
+    @session,
+    @consent_form,
+    attr.to_s.dasherize,
+    options
+  )
+end %>
+
 <%= h1 "Check your answers and confirm", class: "nhsuk-heading-l" %>
 
 <h2 class="nhsuk-heading-m">Consent</h2>
@@ -18,7 +28,7 @@
                          "Yes, I agree to them having a nasal vaccine" :
                          "No" }
         row.with_action(text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, :consent),
+          href: change_link[:consent],
           visually_hidden_text: "consent")
       end
 
@@ -27,19 +37,17 @@
           row.with_key { "Reason" }
           row.with_value { @consent_form.human_enum_name(:reason) }
           row.with_action(text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :reason),
+            href: change_link[:reason],
             visually_hidden_text: "reason for refusal")
         end
-      end
 
-      unless @consent_form.contact_injection.nil?
         summary_list.with_row do |row|
           row.with_key { "Alternative option" }
           row.with_value { @consent_form.contact_injection? ?
                            "A nurse can contact me about an injection" :
                            "No" }
           row.with_action(text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :injection),
+            href: change_link[:injection],
             visually_hidden_text: "alternative option")
         end
       end
@@ -56,7 +64,7 @@
         row.with_key { "Child's name" }
         row.with_value { @consent_form.full_name }
         row.with_action(text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, :name),
+          href: change_link[:name],
           visually_hidden_text: "child's name")
       end
 
@@ -65,7 +73,7 @@
           row.with_key { "Also known as" }
           row.with_value { @consent_form.common_name }
           row.with_action(text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :name),
+            href: change_link[:name],
             visually_hidden_text: "common name")
         end
       end
@@ -75,7 +83,7 @@
         row.with_value { @consent_form.date_of_birth.to_fs(:nhsuk_date) }
         row.with_action(
           text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, "date-of-birth"),
+          href: change_link[:date_of_birth],
           visually_hidden_text: "date of birth"
         )
       end
@@ -86,7 +94,7 @@
           row.with_value { format_address(@consent_form) }
           row.with_action(
             text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, "address"),
+            href: change_link[:address],
             visually_hidden_text: "address"
           )
         end
@@ -97,7 +105,7 @@
         row.with_value { @consent_form.session.location.name }
         row.with_action(
           text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, :school),
+          href: change_link[:school],
           visually_hidden_text: "school"
         )
       end
@@ -108,7 +116,7 @@
           row.with_value { @consent_form.gp_name }
           row.with_action(
             text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :gp),
+            href: change_link[:gp],
             visually_hidden_text: "GP"
           )
         end
@@ -120,7 +128,7 @@
           row.with_value { @consent_form.gp_response_no? ? "No" : "I don’t know" }
           row.with_action(
             text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :gp),
+            href: change_link[:gp],
             visually_hidden_text: "GP"
           )
         end
@@ -138,7 +146,7 @@
         row.with_key { "Your name" }
         row.with_value { @consent_form.parent_name }
         row.with_action(text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, :parent),
+          href: change_link[:parent],
           visually_hidden_text: "your name")
       end
 
@@ -148,7 +156,7 @@
           .human_enum_name(:parent_relationship)
           .capitalize }
         row.with_action(text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, :parent),
+          href: change_link[:parent],
           visually_hidden_text: "your relationship")
       end
 
@@ -156,7 +164,7 @@
         row.with_key { "Email address" }
         row.with_value { @consent_form.parent_email }
         row.with_action(text: "Change",
-          href: session_consent_form_edit_path(@session, @consent_form, :parent),
+          href: change_link[:parent],
           visually_hidden_text: "your email")
       end
 
@@ -165,7 +173,7 @@
           row.with_key { "Phone number" }
           row.with_value { @consent_form.parent_phone }
           row.with_action(text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :parent),
+            href: change_link[:parent],
             visually_hidden_text: "your phone")
         end
 
@@ -173,7 +181,7 @@
           row.with_key { "Phone contact method" }
           row.with_value { contact_method_for(@consent_form) }
           row.with_action(text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, "contact-method"),
+            href: change_link[:contact_method],
             visually_hidden_text: "your phone contact method")
         end
       else
@@ -181,7 +189,7 @@
           row.with_key { "Phone number" }
           row.with_value { "Not provided" }
           row.with_action(text: "Change",
-            href: session_consent_form_edit_path(@session, @consent_form, :parent),
+            href: change_link[:parent],
             visually_hidden_text: "your phone")
         end
       end
@@ -200,11 +208,7 @@
             row.with_key { ha.question }
             row.with_value { health_answer_response(ha) }
             row.with_action(text: "Change",
-              href: session_consent_form_edit_path(
-                @session,
-                @consent_form,
-                "health-#{index + 1}".to_sym
-              ),
+              href: change_link["health-#{index + 1}"],
               visually_hidden_text: "your answer to health question #{index + 1}")
           end
         end


### PR DESCRIPTION
Depends on https://github.com/nhsuk/record-childrens-vaccinations/pull/518.

This sets `skip_to_confirm=true` as a parameter on most of the change links from the confirmation page. If this is set, we then redirect the user to the confirmation page after they submit the step.

See commits.