### PR TITLE
More authorisationz

### DIFF
--- a/app/avo/resources/team_resource.rb
+++ b/app/avo/resources/team_resource.rb
@@ -1,7 +1,6 @@
-class CampaignResource < Avo::BaseResource
-  self.title = :name
+class TeamResource < Avo::BaseResource
+  self.title = :id
   self.includes = []
-  self.record_selector = false
   # self.search_query = -> do
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   # end
@@ -9,8 +8,7 @@ class CampaignResource < Avo::BaseResource
   field :id, as: :id
   # Fields generated from the model
   field :name, as: :text
-  field :sessions, as: :has_many
+  field :campaigns, as: :has_many
+  field :users, as: :has_and_belongs_to_many
   # add fields here
-  field :vaccines, as: :has_and_belongs_to_many
-  field :team, as: :belongs_to
 end

--- a/app/controllers/avo/teams_controller.rb
+++ b/app/controllers/avo/teams_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::TeamsController < Avo::ResourcesController
+end

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -19,6 +19,10 @@ class DevController < ApplicationController
       LoadExampleCampaign.load(
         example_file: "db/sample_data/example-test-campaign.json"
       )
+      LoadExampleCampaign.load(
+        example_file: "db/sample_data/example-flu-campaign.json",
+        new_campaign: true
+      )
     end
 
     redirect_to root_path

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -6,6 +6,8 @@ class TriageController < ApplicationController
   before_action :set_consent, only: %i[show create update]
   before_action :set_vaccination_record, only: %i[show]
 
+  after_action :verify_policy_scoped, only: %i[index show update]
+
   layout "two_thirds", except: %i[index]
 
   def index
@@ -88,7 +90,10 @@ class TriageController < ApplicationController
   private
 
   def set_session
-    @session = Session.find(params.fetch(:session_id) { params.fetch(:id) })
+    @session =
+      policy_scope(Session).find(
+        params.fetch(:session_id) { params.fetch(:id) }
+      )
   end
 
   def set_patient

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -246,7 +246,10 @@ class VaccinationsController < ApplicationController
   end
 
   def set_session
-    @session = Session.find(params.fetch(:session_id) { params.fetch(:id) })
+    @session =
+      policy_scope(Session).find(
+        params.fetch(:session_id) { params.fetch(:id) }
+      )
   end
 
   def set_patient

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,12 +23,12 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/db/sample_data/example-flu-campaign.json
+++ b/db/sample_data/example-flu-campaign.json
@@ -1,0 +1,622 @@
+{
+  "id": "42",
+  "title": "FLU campaign at Oakham School",
+  "location": "Oakham School",
+  "date": "2023-07-28T12:30",
+  "type": "FLU",
+  "team": {
+    "name": "Rutland SAIS team",
+    "users": [
+      {
+        "full_name": "Nurse Jackie",
+        "email": "nurse.jackie@sais"
+      }
+    ]
+  },
+  "vaccines": [
+    {
+      "brand": "Fluenz Tetra",
+      "method": "nasal",
+      "batches": [
+        {
+          "name": "FS7026",
+          "expiry": "2024-03-09"
+        },
+        {
+          "name": "OZ0009",
+          "expiry": "2024-02-25"
+        },
+        {
+          "name": "RM5124",
+          "expiry": "2024-02-02"
+        }
+      ]
+    }
+  ],
+  "school": {
+    "urn": "120322",
+    "name": "Oakham School",
+    "address": "Chapel Close",
+    "locality": "",
+    "address3": "",
+    "town": "Oakham",
+    "county": "Rutland",
+    "postcode": "LE15 6DT",
+    "minimum_age": "9",
+    "maximum_age": "18",
+    "url": "www.oakham.rutland.sch.uk",
+    "phase": "Not applicable",
+    "type": "Independent schools",
+    "detailed_type": "Other independent school"
+  },
+  "healthQuestions": [
+    "Has your child been diagnosed with asthma?",
+    "Has your child had a flu vaccination in the last 5 months?",
+    "Does your child have a disease or treatment that severely affects their immune system?",
+    "Is anyone in your household currently having treatment that severely affects their immune system?",
+    "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+    "Does your child have any allergies to medication?",
+    "Has your child ever had a reaction to previous vaccinations?",
+    "Does you child take regular aspirin?"
+  ],
+  "patients": [
+    {
+      "firstName": "Brittany",
+      "lastName": "Klocko",
+      "dob": "2015-08-29",
+      "nhsNumber": 4656828688,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Zachery Weimann",
+        "parentRelationship": "father",
+        "parentEmail": "zachery.weimann20@gmail.com",
+        "parentPhone": "07168 092638",
+        "healthQuestionResponses": [
+          {
+            "question": "Does the child have a disease or treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Is anyone in your household having treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+            "response": "no"
+          },
+          {
+            "question": "Is there anything else we should know?",
+            "response": "no"
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": "zachery.weimann20@gmail.com",
+      "parentName": "Zachery Weimann",
+      "parentPhone": "07168 092638",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Mckinley",
+      "lastName": "Marvin",
+      "dob": "2016-01-01",
+      "nhsNumber": 4526310840,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Dotty Medhurst",
+        "parentRelationship": "mother",
+        "parentEmail": "dotty.medhurst25@gmail.com",
+        "parentPhone": "07190 868707",
+        "healthQuestionResponses": [
+          {
+            "question": "Does the child have a disease or treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Is anyone in your household having treatment that severely affects their immune system?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no"
+          },
+          {
+            "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+            "response": "no"
+          },
+          {
+            "question": "Is there anything else we should know?",
+            "response": "no"
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": "dotty.medhurst25@gmail.com",
+      "parentName": "Dotty Medhurst",
+      "parentPhone": "07190 868707",
+      "parentRelationship": "mother",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Wonda",
+      "lastName": "Schuster",
+      "dob": "2019-07-26",
+      "nhsNumber": 4007695997,
+      "consent": null,
+      "parentEmail": null,
+      "parentName": "Corey Schuster",
+      "parentPhone": "01462 51984",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Farah",
+      "lastName": "Welch",
+      "dob": "2017-06-01",
+      "nhsNumber": 4817528605,
+      "consent": null,
+      "parentEmail": null,
+      "parentName": "Lauren Welch",
+      "parentPhone": "056 9402 9757",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Evette",
+      "lastName": "Muller",
+      "dob": "2019-03-27",
+      "nhsNumber": 4666534172,
+      "consent": {
+        "response": "refused",
+        "reasonForRefusal": "already_vaccinated",
+        "parentName": "Spencer Hickle",
+        "parentRelationship": "father",
+        "parentEmail": "spencer.hickle89@gmail.com",
+        "parentPhone": "07873 670574",
+        "healthQuestionResponses": [],
+        "route": "website"
+      },
+      "parentEmail": "spencer.hickle89@gmail.com",
+      "parentName": "Spencer Hickle",
+      "parentPhone": "07873 670574",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Bruce",
+      "lastName": "Reynolds",
+      "dob": "2016-06-17",
+      "nhsNumber": 4792147433,
+      "consent": {
+        "response": "refused",
+        "reasonForRefusal": "already_vaccinated",
+        "parentName": "Anibal Funk",
+        "parentRelationship": "father",
+        "parentEmail": "anibal.funk32@gmail.com",
+        "parentPhone": "07517 357328",
+        "healthQuestionResponses": [],
+        "route": "website"
+      },
+      "parentEmail": "anibal.funk32@gmail.com",
+      "parentName": "Anibal Funk",
+      "parentPhone": "07517 357328",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Odelia",
+      "lastName": "Barton",
+      "dob": "2018-02-27",
+      "nhsNumber": 4876927693,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Audrea Hoppe",
+        "parentRelationship": "mother",
+        "parentEmail": "audrea.hoppe94@gmail.com",
+        "parentPhone": "07413 460218",
+        "healthQuestionResponses": [
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child had a flu vaccination in the last 5 months?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have a disease or treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have any allergies to medication?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever had a reaction to previous vaccinations?",
+            "response": "yes",
+            "notes": "Generic note"
+          },
+          {
+            "question": "Does you child take regular aspirin?",
+            "response": "no",
+            "notes": null
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": "audrea.hoppe94@gmail.com",
+      "parentName": "Audrea Hoppe",
+      "parentPhone": "07413 460218",
+      "parentRelationship": "mother",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Rich",
+      "lastName": "Schaden",
+      "dob": "2017-12-12",
+      "nhsNumber": 4362534482,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Dewitt Homenick",
+        "parentRelationship": "father",
+        "parentEmail": "dewitt.homenick41@gmail.com",
+        "parentPhone": "07864 074463",
+        "healthQuestionResponses": [
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child had a flu vaccination in the last 5 months?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have a disease or treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have any allergies to medication?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever had a reaction to previous vaccinations?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does you child take regular aspirin?",
+            "response": "yes",
+            "notes": "Generic note"
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": null,
+      "parentName": "Marvis Schaden",
+      "parentPhone": "0800 628959",
+      "parentRelationship": "mother",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": null
+    },
+    {
+      "firstName": "Sung",
+      "lastName": "Boyle",
+      "dob": "2017-07-07",
+      "nhsNumber": 4336987890,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Melina Homenick",
+        "parentRelationship": "mother",
+        "parentEmail": "melina.homenick94@gmail.com",
+        "parentPhone": "07339 074376",
+        "healthQuestionResponses": [
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child had a flu vaccination in the last 5 months?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have a disease or treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have any allergies to medication?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever had a reaction to previous vaccinations?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does you child take regular aspirin?",
+            "response": "yes",
+            "notes": "Generic note"
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": "melina.homenick94@gmail.com",
+      "parentName": "Melina Homenick",
+      "parentPhone": "07339 074376",
+      "parentRelationship": "mother",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": {
+        "notes": "Generic triage notes",
+        "status": "needs_follow_up"
+      }
+    },
+    {
+      "firstName": "Ted",
+      "lastName": "Swift",
+      "dob": "2016-09-30",
+      "nhsNumber": 4459326590,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Velva Blanda",
+        "parentRelationship": "mother",
+        "parentEmail": "velva.blanda81@gmail.com",
+        "parentPhone": "07177 640668",
+        "healthQuestionResponses": [
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child had a flu vaccination in the last 5 months?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have a disease or treatment that severely affects their immune system?",
+            "response": "yes",
+            "notes": "Generic note"
+          },
+          {
+            "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have any allergies to medication?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever had a reaction to previous vaccinations?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does you child take regular aspirin?",
+            "response": "no",
+            "notes": null
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": null,
+      "parentName": "Rudolf Swift",
+      "parentPhone": "0800 494 8720",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": {
+        "notes": "Generic triage notes",
+        "status": "needs_follow_up"
+      }
+    },
+    {
+      "firstName": "John",
+      "lastName": "Grady",
+      "dob": "2018-02-22",
+      "nhsNumber": 4359409214,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Myrtice Miller",
+        "parentRelationship": "mother",
+        "parentEmail": "myrtice.miller65@gmail.com",
+        "parentPhone": "07755 270530",
+        "healthQuestionResponses": [
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child had a flu vaccination in the last 5 months?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have a disease or treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have any allergies to medication?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever had a reaction to previous vaccinations?",
+            "response": "yes",
+            "notes": "Generic note"
+          },
+          {
+            "question": "Does you child take regular aspirin?",
+            "response": "no",
+            "notes": null
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": null,
+      "parentName": "Cory Grady",
+      "parentPhone": "0928 990 5679",
+      "parentRelationship": "father",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": {
+        "status": "ready_to_vaccinate",
+        "notes": "Checked with GP, OK to proceed"
+      }
+    },
+    {
+      "firstName": "Alysha",
+      "lastName": "Cartwright",
+      "dob": "2016-08-17",
+      "nhsNumber": 4385039321,
+      "consent": {
+        "response": "given",
+        "reasonForRefusal": null,
+        "parentName": "Scott Stark",
+        "parentRelationship": "mother",
+        "parentEmail": "scott.stark46@gmail.com",
+        "parentPhone": "07110 455268",
+        "healthQuestionResponses": [
+          {
+            "question": "Has your child been diagnosed with asthma?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child had a flu vaccination in the last 5 months?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have a disease or treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does your child have any allergies to medication?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Has your child ever had a reaction to previous vaccinations?",
+            "response": "no",
+            "notes": null
+          },
+          {
+            "question": "Does you child take regular aspirin?",
+            "response": "yes",
+            "notes": "Generic note"
+          }
+        ],
+        "route": "website"
+      },
+      "parentEmail": "scott.stark46@gmail.com",
+      "parentName": "Scott Stark",
+      "parentPhone": "07110 455268",
+      "parentRelationship": "mother",
+      "parentRelationshipOther": null,
+      "parentInfoSource": "school",
+      "triage": {
+        "status": "do_not_vaccinate",
+        "notes": "Checked with GP, not OK to proceed"
+      }
+    }
+  ]
+}

--- a/db/sample_data/example-test-campaign.json
+++ b/db/sample_data/example-test-campaign.json
@@ -9,7 +9,7 @@
     "users": [
       {
         "full_name": "Nurse Joy",
-        "username": "nurse.joy"
+        "email": "nurse.joy@sais"
       }
     ]
   },

--- a/db/sample_data/model-office.json
+++ b/db/sample_data/model-office.json
@@ -4,6 +4,15 @@
   "location": "Holyrood Academy",
   "date": "2023-07-28T12:30",
   "type": "HPV",
+  "team": {
+    "name": "Somerset SAIS Team",
+    "users": [
+      {
+        "full_name": "Nurse Joy",
+        "username": "nurse.joy"
+      }
+    ]
+  },
   "vaccines": [
     {
       "brand": "Gardasil 9",

--- a/lib/example_campaign_data.rb
+++ b/lib/example_campaign_data.rb
@@ -126,8 +126,8 @@ class ExampleCampaignData
       name: team_data["name"],
       users:
         team_data["users"].map do |user|
-          { full_name: user["full_name"], username: user["username"] }
+          user.slice("full_name", "username", "email")
         end
-    }
+    }.with_indifferent_access
   end
 end

--- a/lib/example_campaign_generator.rb
+++ b/lib/example_campaign_generator.rb
@@ -52,9 +52,12 @@ class ExampleCampaignGenerator
       raise ArgumentError, "Invalid type #{@type}"
     end
 
+    @username = options.delete(:username)
+
     if presets
       raise "Preset #{presets} not found" unless presettings.key?(presets)
       @type ||= presettings[presets][:type] || self.class.default_type
+      @username ||= presettings[presets][:username]
       @options = presettings[presets].merge(@options)
     else
       @type ||= self.class.default_type
@@ -103,12 +106,13 @@ class ExampleCampaignGenerator
   def user
     @user ||=
       begin
-        nurse_name = Faker::Name.first_name
+        username = @username || "Nurse #{Faker::Name.first_name}"
+        emailname = username.downcase.gsub(" ", ".").gsub(/[^a-z0-9.]/, "")
         FactoryBot.build(
           :user,
           teams: [team],
-          full_name: "Nurse #{nurse_name}",
-          email: "nurse.#{nurse_name.downcase}@sais"
+          full_name: username,
+          email: "#{emailname}@sais"
         )
       end
   end

--- a/lib/load_example_campaign.rb
+++ b/lib/load_example_campaign.rb
@@ -18,15 +18,6 @@ module LoadExampleCampaign
       team.campaigns << campaign unless campaign.in? team.campaigns
       create_users(team:, users: example.team_attributes[:users])
 
-      # Added in for testing, this should be replaced by creating another campaign
-      # to load in the test env, since we'll need that for testing other aspects
-      # like authorisation.
-      other_team = Team.find_or_initialize_by(name: "Other SAIS Team")
-      create_users(
-        team: other_team,
-        users: [{ full_name: "Nurse Jackie", username: "nurse.jackie" }]
-      )
-
       campaign.save!
 
       school = create_school(example)

--- a/lib/tasks/generate_example_campaign.rake
+++ b/lib/tasks/generate_example_campaign.rake
@@ -11,6 +11,7 @@ Option (set these as env vars, e.g. seed=42):
   presets: Use preset values for the following options. These can be overridden with patients_* options. Available presets:
     - model_office
   type: Type of campaign to generate, one of: hpv, flu (default: ExampleCampaignGenerator.default_type)
+  username: Name of the user to be added to the team. An email address will be generated using this.
 
 Options controlling number of patients to generate:
 #{ExampleCampaignGenerator.patient_options.map { |option| "  #{option}" }.join("\n")}
@@ -34,7 +35,9 @@ task :generate_example_campaign,
     campaign_options[:presets] = :default
   end
 
-  generator = ExampleCampaignGenerator.new(seed:, **campaign_options)
+  username = ENV["username"]
+
+  generator = ExampleCampaignGenerator.new(seed:, username:, **campaign_options)
   data = generator.generate
 
   IO.write(example_file, JSON.pretty_generate(data))

--- a/tests/session_authorisation.spec.ts
+++ b/tests/session_authorisation.spec.ts
@@ -9,7 +9,7 @@ test("Session authorisation", async ({ page }) => {
   await given_the_app_is_setup();
   await when_i_sign_in_as_a_nurse_from_another_team();
   await and_i_go_to_the_sessions_list();
-  await then_i_should_see_no_sessions();
+  await then_i_should_see_only_my_session();
 
   await when_i_go_to_a_session_belonging_to_another_team();
   await then_i_should_get_an_error();
@@ -20,18 +20,23 @@ async function given_the_app_is_setup() {
 }
 
 async function when_i_sign_in_as_a_nurse_from_another_team() {
-  await signInTestUser(p, "nurse.jackie@test", "nurse.jackie@test");
+  await signInTestUser(p, "nurse.jackie@sais", "nurse.jackie@sais");
 }
 
 async function and_i_go_to_the_sessions_list() {
   await p.goto("/sessions");
 }
 
-async function then_i_should_see_no_sessions() {
+async function then_i_should_see_only_my_session() {
   await expect(
     p.getByRole("heading", { name: "School sessions" }),
   ).toBeVisible();
-  await expect(p.locator(".nhsuk-table__row")).not.toBeVisible();
+  await expect(p.locator(".nhsuk-table__body .nhsuk-table__row")).toHaveCount(
+    1,
+  );
+  await expect(p.locator(".nhsuk-table__body .nhsuk-table__row")).toHaveText(
+    /FLU campaign at Oakham School/,
+  );
 }
 
 async function when_i_go_to_a_session_belonging_to_another_team() {

--- a/tests/session_authorisation.spec.ts
+++ b/tests/session_authorisation.spec.ts
@@ -10,6 +10,9 @@ test("Session authorisation", async ({ page }) => {
   await when_i_sign_in_as_a_nurse_from_another_team();
   await and_i_go_to_the_sessions_list();
   await then_i_should_see_no_sessions();
+
+  await when_i_go_to_a_session_belonging_to_another_team();
+  await then_i_should_get_an_error();
 });
 
 async function given_the_app_is_setup() {
@@ -29,4 +32,14 @@ async function then_i_should_see_no_sessions() {
     p.getByRole("heading", { name: "School sessions" }),
   ).toBeVisible();
   await expect(p.locator(".nhsuk-table__row")).not.toBeVisible();
+}
+
+async function when_i_go_to_a_session_belonging_to_another_team() {
+  await p.goto("/sessions/1");
+}
+
+async function then_i_should_get_an_error() {
+  await expect(
+    p.getByRole("heading", { name: "Page not found" }),
+  ).toBeVisible();
 }

--- a/tests/shared/sign_in.ts
+++ b/tests/shared/sign_in.ts
@@ -1,7 +1,7 @@
 export async function signInTestUser(
   page,
-  username = "nurse.joy@test",
-  password = "nurse.joy@test",
+  username = "nurse.joy@sais",
+  password = "nurse.joy@sais",
 ) {
   await page.goto("/users/sign-in");
   await page.getByLabel("Email address").fill(username);

--- a/tests/triage_authorisation.spec.ts
+++ b/tests/triage_authorisation.spec.ts
@@ -20,7 +20,7 @@ async function given_the_app_is_setup() {
 }
 
 async function when_i_sign_in_as_a_nurse_from_another_team() {
-  await signInTestUser(p, "nurse.jackie@test", "nurse.jackie@test");
+  await signInTestUser(p, "nurse.jackie@sais", "nurse.jackie@sais");
 }
 
 async function and_i_go_to_the_triage_page() {

--- a/tests/triage_authorisation.spec.ts
+++ b/tests/triage_authorisation.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser } from "./shared/sign_in";
+
+let p: Page;
+
+test("Triage authorisation", async ({ page }) => {
+  p = page;
+
+  await given_the_app_is_setup();
+  await when_i_sign_in_as_a_nurse_from_another_team();
+  await and_i_go_to_the_triage_page();
+  await then_i_should_get_an_error();
+
+  await when_i_go_to_triage_a_patient_belonging_to_another_team();
+  await then_i_should_get_an_error();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function when_i_sign_in_as_a_nurse_from_another_team() {
+  await signInTestUser(p, "nurse.jackie@test", "nurse.jackie@test");
+}
+
+async function and_i_go_to_the_triage_page() {
+  await p.goto("/sessions/1/triage");
+}
+
+async function then_i_should_get_an_error() {
+  await expect(
+    p.getByRole("heading", { name: "Page not found" }),
+  ).toBeVisible();
+}
+
+async function when_i_go_to_triage_a_patient_belonging_to_another_team() {
+  await p.goto("/sessions/1/patients/1/triage");
+}

--- a/tests/triage_authorisation.spec.ts
+++ b/tests/triage_authorisation.spec.ts
@@ -9,6 +9,9 @@ test("Triage authorisation", async ({ page }) => {
   await given_the_app_is_setup();
   await when_i_sign_in_as_a_nurse_from_another_team();
   await and_i_go_to_the_triage_page();
+  await then_i_should_only_see_my_patients();
+
+  await when_i_go_to_the_triage_page_of_another_team();
   await then_i_should_get_an_error();
 
   await when_i_go_to_triage_a_patient_belonging_to_another_team();
@@ -24,6 +27,20 @@ async function when_i_sign_in_as_a_nurse_from_another_team() {
 }
 
 async function and_i_go_to_the_triage_page() {
+  await p.goto("/sessions/2/triage");
+}
+
+async function then_i_should_only_see_my_patients() {
+  await expect(
+    p.locator("#needs-triage-4 .nhsuk-table__body .nhsuk-table__row"),
+  ).toHaveCount(4);
+  await expect(p.getByText("Odelia Barton")).toBeVisible();
+  await expect(p.getByText("Rich Schaden")).toBeVisible();
+  await expect(p.getByText("Sung Boyle")).toBeVisible();
+  await expect(p.getByText("Ted Swift")).toBeVisible();
+}
+
+async function when_i_go_to_the_triage_page_of_another_team() {
   await p.goto("/sessions/1/triage");
 }
 

--- a/tests/vaccination_authorisation.spec.ts
+++ b/tests/vaccination_authorisation.spec.ts
@@ -9,9 +9,12 @@ test("Vaccination authorisation", async ({ page }) => {
   await given_the_app_is_setup();
   await when_i_sign_in_as_a_nurse_from_another_team();
   await and_i_go_to_the_vaccinations_page();
+  await then_i_should_only_see_my_patients();
+
+  await when_i_go_to_the_vaccinations_page_of_another_team();
   await then_i_should_get_an_error();
 
-  await when_i_go_to_the_record_vaccination_page_belonging_to_another_team();
+  await when_i_go_to_the_vaccination_record_page_belonging_to_another_team();
   await then_i_should_get_an_error();
 });
 
@@ -24,6 +27,27 @@ async function when_i_sign_in_as_a_nurse_from_another_team() {
 }
 
 async function and_i_go_to_the_vaccinations_page() {
+  await p.goto("/sessions/2/vaccinations");
+}
+
+async function then_i_should_only_see_my_patients() {
+  await expect(
+    p.locator("#action-needed-11 .nhsuk-table__body .nhsuk-table__row"),
+  ).toHaveCount(11);
+  await expect(p.getByText("Brittany Klocko")).toBeVisible();
+  await expect(p.getByText("Bruce Reynolds")).toBeVisible();
+  await expect(p.getByText("Evette Muller")).toBeVisible();
+  await expect(p.getByText("Farah Welch")).toBeVisible();
+  await expect(p.getByText("John Grady")).toBeVisible();
+  await expect(p.getByText("Mckinley Marvin")).toBeVisible();
+  await expect(p.getByText("Odelia Barton")).toBeVisible();
+  await expect(p.getByText("Rich Schaden")).toBeVisible();
+  await expect(p.getByText("Sung Boyle")).toBeVisible();
+  await expect(p.getByText("Ted Swift")).toBeVisible();
+  await expect(p.getByText("Wonda Schuster")).toBeVisible();
+}
+
+async function when_i_go_to_the_vaccinations_page_of_another_team() {
   await p.goto("/sessions/1/vaccinations");
 }
 
@@ -33,6 +57,6 @@ async function then_i_should_get_an_error() {
   ).toBeVisible();
 }
 
-async function when_i_go_to_the_record_vaccination_page_belonging_to_another_team() {
+async function when_i_go_to_the_vaccination_record_page_belonging_to_another_team() {
   await p.goto("/sessions/1/patients/1/vaccinations");
 }

--- a/tests/vaccination_authorisation.spec.ts
+++ b/tests/vaccination_authorisation.spec.ts
@@ -20,7 +20,7 @@ async function given_the_app_is_setup() {
 }
 
 async function when_i_sign_in_as_a_nurse_from_another_team() {
-  await signInTestUser(p, "nurse.jackie@test", "nurse.jackie@test");
+  await signInTestUser(p, "nurse.jackie@sais", "nurse.jackie@sais");
 }
 
 async function and_i_go_to_the_vaccinations_page() {

--- a/tests/vaccination_authorisation.spec.ts
+++ b/tests/vaccination_authorisation.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser } from "./shared/sign_in";
+
+let p: Page;
+
+test("Vaccination authorisation", async ({ page }) => {
+  p = page;
+
+  await given_the_app_is_setup();
+  await when_i_sign_in_as_a_nurse_from_another_team();
+  await and_i_go_to_the_vaccinations_page();
+  await then_i_should_get_an_error();
+
+  await when_i_go_to_the_record_vaccination_page_belonging_to_another_team();
+  await then_i_should_get_an_error();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function when_i_sign_in_as_a_nurse_from_another_team() {
+  await signInTestUser(p, "nurse.jackie@test", "nurse.jackie@test");
+}
+
+async function and_i_go_to_the_vaccinations_page() {
+  await p.goto("/sessions/1/vaccinations");
+}
+
+async function then_i_should_get_an_error() {
+  await expect(
+    p.getByRole("heading", { name: "Page not found" }),
+  ).toBeVisible();
+}
+
+async function when_i_go_to_the_record_vaccination_page_belonging_to_another_team() {
+  await p.goto("/sessions/1/patients/1/vaccinations");
+}


### PR DESCRIPTION
**NB: This PR depends on #533**

Add authorisation to triage and vaccination controllers. Users will only be able to see the patients that are in campaigns that their team are running.

In addition to adding the policies, a lot of the work was uplifting the testing environment:
- Allow error pages to be rendered in the test environment
- Allow usernames to be specified when generating example campaigns (to support consistent usernames in tests)
- Add example flu campaign and load it in `/reset`
- And, of course, adding tests for the triage and vaccinations pages