### PR TITLE
Load example campaign

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -16,10 +16,11 @@ class DevController < ApplicationController
         )
       end
 
-      Rake::Task["load_campaign_example"].execute(
+      LoadExampleCampaign.load(
         example_file: "db/sample_data/example-test-campaign.json"
       )
     end
+
     redirect_to root_path
   end
 end

--- a/lib/load_example_campaign.rb
+++ b/lib/load_example_campaign.rb
@@ -9,7 +9,9 @@ module LoadExampleCampaign
         if new_campaign
           Campaign.new(example.campaign_attributes)
         else
-          Campaign.find_or_initialize_by(name: example.campaign_attributes[:name])
+          Campaign.find_or_initialize_by(
+            name: example.campaign_attributes[:name]
+          )
         end
 
       team = Team.find_or_initialize_by(name: example.team_attributes[:name])
@@ -27,52 +29,12 @@ module LoadExampleCampaign
 
       campaign.save!
 
-      school = Location.find_or_create_by!(name: example.school_attributes[:name])
-      school.update!(example.school_attributes)
+      school = create_school(example)
+      create_vaccine_and_batches(example, campaign:)
+      session = create_session(example, campaign:, school:)
 
-      example.vaccine_attributes.each do |attributes|
-        batches = attributes.delete(:batches)
-        vaccine = Vaccine.find_or_create_by!(attributes)
-        batches.each { |batch| vaccine.batches.find_or_create_by!(batch) }
-        campaign.vaccines << vaccine unless vaccine.in? campaign.vaccines
-      end
-
-      session =
-        Session.find_or_initialize_by(
-          campaign:,
-          name: example.session_attributes[:name]
-        )
-      session.update!(example.session_attributes)
-      session.location = school if session.location.blank?
-      session.save!
-
-      vaccine = campaign.vaccines.first
-      vaccine.health_questions =
-        example.health_question_attributes.map do |attributes|
-        HealthQuestion.find_or_initialize_by(attributes.merge(vaccine:))
-      end
-
-      example.children_attributes.each do |attributes|
-        triage_attributes = attributes.delete(:triage)
-        consent_attributes = attributes.delete(:consent)
-
-        patient =
-          Patient.find_or_initialize_by(nhs_number: attributes[:nhs_number])
-        patient.update!(attributes)
-        patient_session = PatientSession.find_or_create_by!(patient:, session:)
-
-        if triage_attributes.present?
-          triage = Triage.find_or_initialize_by(patient_session:)
-          triage.update!(triage_attributes)
-        end
-
-        next if consent_attributes.blank?
-        consent = Consent.find_or_initialize_by(campaign:, patient:)
-        consent.update!(consent_attributes.merge(recorded_at: Time.zone.now))
-        patient.consents << consent unless patient.consents.include?(consent)
-
-        transition_states(patient.patient_sessions.first)
-      end
+      create_vaccine_health_questions(example, campaign:)
+      create_children(example, campaign:, session:)
     end
   end
 
@@ -87,20 +49,77 @@ module LoadExampleCampaign
     users.map do |attributes|
       email =
         attributes.fetch(:email) do
-        username = attributes[:username]
-        username ||= attributes[:full_name]&.downcase&.gsub(/\s+/, ".")
-        env_name = { "development" => "dev" }.fetch(Rails.env, Rails.env)
-        "#{username}@#{env_name}"
-      end
+          username = attributes[:username]
+          username ||= attributes[:full_name]&.downcase&.gsub(/\s+/, ".")
+          env_name = { "development" => "dev" }.fetch(Rails.env, Rails.env)
+          "#{username}@#{env_name}"
+        end
       User
         .find_or_initialize_by(email:)
         .tap do |user|
-        user.full_name = attributes[:full_name]
-        user.password = email
-        user.password_confirmation = email
-        user.teams << team unless user.teams.include?(team)
-        user.save!
+          user.full_name = attributes[:full_name]
+          user.password = email
+          user.password_confirmation = email
+          user.teams << team unless user.teams.include?(team)
+          user.save!
+        end
+    end
+  end
+
+  def self.create_school(example)
+    Location
+      .find_or_create_by!(name: example.school_attributes[:name])
+      .tap { |school| school.update!(example.school_attributes) }
+  end
+
+  def self.create_vaccine_and_batches(example, campaign:)
+    example.vaccine_attributes.each do |attributes|
+      batches = attributes.delete(:batches)
+      vaccine = Vaccine.find_or_create_by!(attributes)
+      batches.each { |batch| vaccine.batches.find_or_create_by!(batch) }
+      campaign.vaccines << vaccine unless vaccine.in? campaign.vaccines
+    end
+  end
+
+  def self.create_vaccine_health_questions(example, campaign:)
+    vaccine = campaign.vaccines.first
+    vaccine.health_questions =
+      example.health_question_attributes.map do |attributes|
+        HealthQuestion.find_or_initialize_by(attributes.merge(vaccine:))
       end
+  end
+
+  def self.create_session(example, campaign:, school:)
+    Session
+      .find_or_initialize_by(campaign:, name: example.session_attributes[:name])
+      .tap do |session|
+        session.update!(example.session_attributes)
+        session.location = school if session.location.blank?
+        session.save!
+      end
+  end
+
+  def self.create_children(example, campaign:, session:)
+    example.children_attributes.each do |attributes|
+      triage_attributes = attributes.delete(:triage)
+      consent_attributes = attributes.delete(:consent)
+
+      patient =
+        Patient.find_or_initialize_by(nhs_number: attributes[:nhs_number])
+      patient.update!(attributes)
+      patient_session = PatientSession.find_or_create_by!(patient:, session:)
+
+      if triage_attributes.present?
+        triage = Triage.find_or_initialize_by(patient_session:)
+        triage.update!(triage_attributes)
+      end
+
+      next if consent_attributes.blank?
+      consent = Consent.find_or_initialize_by(campaign:, patient:)
+      consent.update!(consent_attributes.merge(recorded_at: Time.zone.now))
+      patient.consents << consent unless patient.consents.include?(consent)
+
+      transition_states(patient.patient_sessions.first)
     end
   end
 end

--- a/lib/load_example_campaign.rb
+++ b/lib/load_example_campaign.rb
@@ -1,0 +1,106 @@
+require "example_campaign_data"
+
+module LoadExampleCampaign
+  def self.load(example_file:, new_campaign: false)
+    example = ExampleCampaignData.new(data_file: Rails.root.join(example_file))
+
+    ActiveRecord::Base.transaction do
+      campaign =
+        if new_campaign
+          Campaign.new(example.campaign_attributes)
+        else
+          Campaign.find_or_initialize_by(name: example.campaign_attributes[:name])
+        end
+
+      team = Team.find_or_initialize_by(name: example.team_attributes[:name])
+      team.campaigns << campaign unless campaign.in? team.campaigns
+      create_users(team:, users: example.team_attributes[:users])
+
+      # Added in for testing, this should be replaced by creating another campaign
+      # to load in the test env, since we'll need that for testing other aspects
+      # like authorisation.
+      other_team = Team.find_or_initialize_by(name: "Other SAIS Team")
+      create_users(
+        team: other_team,
+        users: [{ full_name: "Nurse Jackie", username: "nurse.jackie" }]
+      )
+
+      campaign.save!
+
+      school = Location.find_or_create_by!(name: example.school_attributes[:name])
+      school.update!(example.school_attributes)
+
+      example.vaccine_attributes.each do |attributes|
+        batches = attributes.delete(:batches)
+        vaccine = Vaccine.find_or_create_by!(attributes)
+        batches.each { |batch| vaccine.batches.find_or_create_by!(batch) }
+        campaign.vaccines << vaccine unless vaccine.in? campaign.vaccines
+      end
+
+      session =
+        Session.find_or_initialize_by(
+          campaign:,
+          name: example.session_attributes[:name]
+        )
+      session.update!(example.session_attributes)
+      session.location = school if session.location.blank?
+      session.save!
+
+      vaccine = campaign.vaccines.first
+      vaccine.health_questions =
+        example.health_question_attributes.map do |attributes|
+        HealthQuestion.find_or_initialize_by(attributes.merge(vaccine:))
+      end
+
+      example.children_attributes.each do |attributes|
+        triage_attributes = attributes.delete(:triage)
+        consent_attributes = attributes.delete(:consent)
+
+        patient =
+          Patient.find_or_initialize_by(nhs_number: attributes[:nhs_number])
+        patient.update!(attributes)
+        patient_session = PatientSession.find_or_create_by!(patient:, session:)
+
+        if triage_attributes.present?
+          triage = Triage.find_or_initialize_by(patient_session:)
+          triage.update!(triage_attributes)
+        end
+
+        next if consent_attributes.blank?
+        consent = Consent.find_or_initialize_by(campaign:, patient:)
+        consent.update!(consent_attributes.merge(recorded_at: Time.zone.now))
+        patient.consents << consent unless patient.consents.include?(consent)
+
+        transition_states(patient.patient_sessions.first)
+      end
+    end
+  end
+
+  def self.transition_states(patient_session)
+    patient_session.do_consent if patient_session.may_do_consent?
+    patient_session.do_triage if patient_session.may_do_triage?
+    patient_session.do_vaccination if patient_session.may_do_vaccination?
+    patient_session.save!
+  end
+
+  def self.create_users(team:, users:)
+    users.map do |attributes|
+      email =
+        attributes.fetch(:email) do
+        username = attributes[:username]
+        username ||= attributes[:full_name]&.downcase&.gsub(/\s+/, ".")
+        env_name = { "development" => "dev" }.fetch(Rails.env, Rails.env)
+        "#{username}@#{env_name}"
+      end
+      User
+        .find_or_initialize_by(email:)
+        .tap do |user|
+        user.full_name = attributes[:full_name]
+        user.password = email
+        user.password_confirmation = email
+        user.teams << team unless user.teams.include?(team)
+        user.save!
+      end
+    end
+  end
+end

--- a/lib/tasks/load_campaign_example.rake
+++ b/lib/tasks/load_campaign_example.rake
@@ -1,110 +1,18 @@
-require "example_campaign_data"
+require "load_example_campaign"
 
 desc "Load campaign example file into db"
-task :load_campaign_example, [:example_file] => :environment do |_task, args|
-  new_campaign = ENV.fetch("new_campaign", false).in? %w[true 1 yes]
+task :load_campaign_example,
+     %i[example_file new_campaign] => :environment do |_task, args|
+  new_campaign =
+    args.fetch(:new_campaign) { ENV.fetch("new_campaign", false) }.in? [
+            true,
+            "true",
+            "1",
+            "yes"
+          ]
 
   example_file =
     args.fetch(:example_file, "db/sample_data/example-campaign.json")
 
-  example = ExampleCampaignData.new(data_file: Rails.root.join(example_file))
-
-  ActiveRecord::Base.transaction do
-    campaign =
-      if new_campaign
-        Campaign.new(example.campaign_attributes)
-      else
-        Campaign.find_or_initialize_by(name: example.campaign_attributes[:name])
-      end
-
-    team = Team.find_or_initialize_by(name: example.team_attributes[:name])
-    team.campaigns << campaign unless campaign.in? team.campaigns
-    create_users(team:, users: example.team_attributes[:users])
-
-    # Added in for testing, this should be replaced by creating another campaign
-    # to load in the test env, since we'll need that for testing other aspects
-    # like authorisation.
-    other_team = Team.find_or_initialize_by(name: "Other SAIS Team")
-    create_users(
-      team: other_team,
-      users: [{ full_name: "Nurse Jackie", username: "nurse.jackie" }]
-    )
-
-    campaign.save!
-
-    school = Location.find_or_create_by!(name: example.school_attributes[:name])
-    school.update!(example.school_attributes)
-
-    example.vaccine_attributes.each do |attributes|
-      batches = attributes.delete(:batches)
-      vaccine = Vaccine.find_or_create_by!(attributes)
-      batches.each { |batch| vaccine.batches.find_or_create_by!(batch) }
-      campaign.vaccines << vaccine unless vaccine.in? campaign.vaccines
-    end
-
-    session =
-      Session.find_or_initialize_by(
-        campaign:,
-        name: example.session_attributes[:name]
-      )
-    session.update!(example.session_attributes)
-    session.location = school if session.location.blank?
-    session.save!
-
-    vaccine = campaign.vaccines.first
-    vaccine.health_questions =
-      example.health_question_attributes.map do |attributes|
-        HealthQuestion.find_or_initialize_by(attributes.merge(vaccine:))
-      end
-
-    example.children_attributes.each do |attributes|
-      triage_attributes = attributes.delete(:triage)
-      consent_attributes = attributes.delete(:consent)
-
-      patient =
-        Patient.find_or_initialize_by(nhs_number: attributes[:nhs_number])
-      patient.update!(attributes)
-      patient_session = PatientSession.find_or_create_by!(patient:, session:)
-
-      if triage_attributes.present?
-        triage = Triage.find_or_initialize_by(patient_session:)
-        triage.update!(triage_attributes)
-      end
-
-      next if consent_attributes.blank?
-      consent = Consent.find_or_initialize_by(campaign:, patient:)
-      consent.update!(consent_attributes.merge(recorded_at: Time.zone.now))
-      patient.consents << consent unless patient.consents.include?(consent)
-
-      transition_states(patient.patient_sessions.first)
-    end
-  end
-end
-
-def transition_states(patient_session)
-  patient_session.do_consent if patient_session.may_do_consent?
-  patient_session.do_triage if patient_session.may_do_triage?
-  patient_session.do_vaccination if patient_session.may_do_vaccination?
-  patient_session.save!
-end
-
-def create_users(team:, users:)
-  users.map do |attributes|
-    email =
-      attributes.fetch(:email) do
-        username = attributes[:username]
-        username ||= attributes[:full_name]&.downcase&.gsub(/\s+/, ".")
-        env_name = { "development" => "dev" }.fetch(Rails.env, Rails.env)
-        "#{username}@#{env_name}"
-      end
-    User
-      .find_or_initialize_by(email:)
-      .tap do |user|
-        user.full_name = attributes[:full_name]
-        user.password = email
-        user.password_confirmation = email
-        user.teams << team unless user.teams.include?(team)
-        user.save!
-      end
-  end
+  LoadExampleCampaign.load(example_file:, new_campaign:)
 end


### PR DESCRIPTION
Add `LoadExampleCampaign` and use it from the `load_example_campaign` Rake task and from `/reset`.

This was motivated by strange behaviour when using `/reset` whereby for each time `/reset` was triggered, the action would trigger the task n+1 times. This wasn't noticeable when we the HPV campaign was being created with `find_or_create`, but with the new tests where we've added another campaign which simply uses `create`, we were getting many copies of the same campaign and related data.