### PR TITLE
Update architecture docs

### DIFF
--- a/docs/architecture-future.adoc
+++ b/docs/architecture-future.adoc
@@ -29,15 +29,16 @@ endif::[]
 
 == Introduction and Goals
 
-This is the pilot of a service to record children's vaccinations in schools and
-during catch-up clinics. This service provides consent and point-of-care
-services for SAIS teams and parents, and is designed to integrate with the
-Personal Demographics Service (PDS) and the national vaccination record.
+This is the pilot a service to manage vaccinations for school-aged children in
+schools and during catch-up clinics. This service will provide e-consent,
+campaign management and point-of-care services for SAIS teams and parents. The
+goal is for this service to integrate with the national vaccination record to
+record vaccinations.
 
-This service is in Alpha and this pilot is being used in to explore designs and further
-our understandings of user requirements through user research. Requirements have
-been tailored to focus on user-facing features over non-functional requirements
-which have been, where possible, de-emphasised.
+This service is in Alpha and this pilot is being used in to explore designs and
+further our understandings of user requirements through user research.
+Requirements have been tailored to focus on user-facing features over
+non-functional requirements which have been, where possible, de-emphasised.
 
 === Requirements Overview
 
@@ -53,7 +54,8 @@ which have been, where possible, de-emphasised.
 .Non-Functional Requirements
 
 * Security
-** Simple authentication and authorisation model; the alpha team will issue individual logins, tied to email addresses, to each SAIS user.
+** Simple authentication and authorisation model; the alpha team will issue
+   individual logins, tied to email addresses, to each SAIS user.
 ** Security model appropriate for scale of experiment
 *** Each SAIS team will only be able to view and record vaccinations/patients
     for the school sessions that they manage
@@ -66,7 +68,7 @@ which have been, where possible, de-emphasised.
 ** Web application framework that enables accelerated delivery
 * Data persistence
 ** Data persisted between sessions and users
-** No long term data storage, i.e. beyond end of experiment
+** No long term data storage, i.e. beyond end of testing phase(s)
 ** Support for offline functionality
 * Integration with NHS services (where possible)
 ** Send events to National Vaccination Record
@@ -91,7 +93,7 @@ We won't need:
   and not constrained to run on any one cloud platform.
 * The system must be deployed to NHS approved platforms.
 
-Additionally, there are some integrations which would be required in the
+Additionally, there are some integrations which will be required in the
 production service, but which we consider optional while in Alpha. Where
 possible we will try to integrate with these services, but not treat it as a
 blocker if we cannot:
@@ -177,6 +179,11 @@ ifndef::env-github[]
 include::diagrams/container-view-future.puml[]
 ----
 endif::[]
+
+GOVUK Notify::
+This service used to send consent confirmations and other notifications to
+parents. It is an external service run by Government Digital Service (GDS) and
+in use by other NHS services.
 
 === Level 2: Component View
 

--- a/docs/architecture-future.adoc
+++ b/docs/architecture-future.adoc
@@ -1,0 +1,233 @@
+:imagesdir: images
+:source-highlighter: pygments
+
+ifdef::env-github[]
+// If on GitHub, define attributes so we can find our diagram files and render
+// them.
+
+// The branch will be used to find the correct diagrams to render below.
+// When PRing changes to the diagrams you can change this attributes
+// temporarily to the name of the branch you're working on. But don't forget
+// to change it back to main before merging!!
+:github-branch: main
+
+:github-repo: nhsuk/record-childrens-vaccinations
+
+// URL for PlantUML Proxy. Using an attribute mainly because it's just tidier.
+:plantuml-proxy-url: http://www.plantuml.com/plantuml/proxy?cache=no&src=
+
+// Full path prefix we'll use for diagrams below.
+:diagram-path-url: {plantuml-proxy-url}https://raw.githubusercontent.com/{github-repo}/{github-branch}/docs
+endif::[]
+
+:toc:
+
+= Architecture
+
+:sectnums:
+:sectnumlevels: 2
+
+== Introduction and Goals
+
+This is the pilot of a service to record children's vaccinations in schools and
+during catch-up clinics. This service provides consent and point-of-care
+services for SAIS teams and parents, and is designed to integrate with the
+Personal Demographics Service (PDS) and the national vaccination record.
+
+This service is in Alpha and this pilot is being used in to explore designs and further
+our understandings of user requirements through user research. Requirements have
+been tailored to focus on user-facing features over non-functional requirements
+which have been, where possible, de-emphasised.
+
+=== Requirements Overview
+
+.Functional Requirements
+
+* Allow SAIS teams to deliver vaccination campaigns.
+** Manage vaccination campaigns including location and cohort information.
+** Create consent invites.
+** Record vaccinations administered.
+* Allow parents to respond to consent requests.
+* Operate in settings where there is no Internet access, i.e. offline working.
+
+.Non-Functional Requirements
+
+* Security
+** Simple authentication and authorisation model; the alpha team will issue individual logins, tied to email addresses, to each SAIS user.
+** Security model appropriate for scale of experiment
+*** Each SAIS team will only be able to view and record vaccinations/patients
+    for the school sessions that they manage
+*** The service will be available on the public internet with no IP address
+    range restrictions
+** No integration with NHS CIS 2 or other SSO provider, this isn't required yet
+* Rapid development
+** Cloud-based deployment
+** CI & CD for fast and stable deployment
+** Web application framework that enables accelerated delivery
+* Data persistence
+** Data persisted between sessions and users
+** No long term data storage, i.e. beyond end of experiment
+** Support for offline functionality
+* Integration with NHS services (where possible)
+** Send events to National Vaccination Record
+** Use Personal Demographic Service (PDS) to perform NHS number lookup
+
+We won't need:
+
+* Scalability
+* Authentication that's integrated with wider NHS or other SSO provider
+* Reporting capability
+* Long term maintainability of codebase
+* Long term storage of data
+
+<<<<
+== Architecture Constraints
+
+* The system must protect patient data and comply with all applicable laws and
+  regulations.
+* The system will adhere to the applicable NHS architecture and design
+  principles.
+* The system must be deployed to a cloud platform, but also be platform agnostic
+  and not constrained to run on any one cloud platform.
+* The system must be deployed to NHS approved platforms.
+
+Additionally, there are some integrations which would be required in the
+production service, but which we consider optional while in Alpha. Where
+possible we will try to integrate with these services, but not treat it as a
+blocker if we cannot:
+
+* National vaccination record service, to update the vaccination record for
+  the patient. We do not yet know what this system looks like so it is unlikely
+  we'll be able to integrate with it properly. However we anticipate that
+  whatever this system is, it will have a FHIR API which we can use to update
+  the vaccination record. As this is a convenient technical abstraction point
+  for whatever the future system is, we will demonstrate that we can update a
+  FHIR API when an vaccination is administered as a proof of concept in this
+  Alpha.
+* The Personal Demographic Service (PDS) will be used to look up patient's NHS
+  numbers using their name and date of birth. Because we are using real patient
+  data from a non-live service, there may be serious hurdles to integrating with
+  PDS, and we may need to drop this requirements or opt for a mock server if we
+  think that will be beneficial.
+
+<<<<
+== System Scope and Context
+
+ifdef::env-github[]
+image::{diagram-path-url}/diagrams/context-view-future.puml[Context view diagram]
+endif::[]
+
+ifndef::env-github[]
+[plantuml,align="center"]
+----
+include::diagrams/context-view-future.puml[]
+----
+endif::[]
+
+SAIS Team::
+Team responsible for performing vaccinations on school-aged children.
+
+Parents::
+Parents are notified of the planned vaccination campaign and invited to give
+consent for their children to be vaccinated.
+
+Manage vaccinations for school-aged children Service::
+The service will be used by the SAIS team to record vaccinations.
+
+Vaccination Record::
+
+Service which will hold a record of vaccinations for citizens across the NHS.
+This service is currently being designed and it's final form is yet to be
+determined, however any new service created will very likely use a Rest
+FHIR API.
++
+However, it is possible that in the interim this service will be DPS, which is
+built using Data Bricks and which uses file transfers for data input and output,
+so may present additional challenges.
++
+This integration may not be available during during this alpha.
+
+PDS (Personal Demographics Service)::
+Service which will allow us to look up NHS numbers for patients who don't know
+theirs. Crucial for properly identifying patients.
++
+This integration may not be available during during this alpha.
+
+== Solution strategy
+
+Certain solution strategy decisions are recorded as architecture decisions in
+the Architecture Decision Records (ADRs), which can be found in link:../adr/[the
+`adr` directory at the root of this repository]. Relevant ADRs:
+
+* link:../adr/00002-begin-with-a-monolithic-application-architecture.md[ADR 2:
+  Application Architecture]
+* link:../adr/00004-language-and-framework.md[ADR 4: Language and framework]
+
+== Building Blocks View
+
+=== Level 1: Container View
+
+ifdef::env-github[]
+image::{diagram-path-url}/diagrams/container-view-future.puml[Container view diagram]
+endif::[]
+
+ifndef::env-github[]
+[plantuml,align="center"]
+----
+include::diagrams/container-view-future.puml[]
+----
+endif::[]
+
+=== Level 2: Component View
+
+ifdef::env-github[]
+image::{diagram-path-url}/diagrams/component-view-future.puml[Component view diagram]
+endif::[]
+
+ifndef::env-github[]
+[plantuml,align="center"]
+----
+include::diagrams/component-view-future.puml[]
+----
+endif::[]
+
+Browser Cache Storage::
+Data necessary for offline functionality is stored in the browser's cache
+storage. This is managed by the service worker, see the offline documentation
+for more information.
+
+Database::
+Relational storage used to store application data including campaign data,
+consent responses and vaccination events. In the case of the vaccination events,
+this data would be uploaded to the national vaccination record and this data
+store would be used as temporary storage. However during the alpha phase
+uploading to the national vaccination record may not available, so the
+vaccination event data may be kept in this store until the end of the pilot.
+
+== Runtime View
+
+The Manage vaccinations for school-aged children service is built largely as a
+standard server-rendered web application: HTML pages are rendered on the server
+and delivered along with CSS and JavaScript to the client. Users login to the
+service using a standard login page, and as is standard with Ruby on Rails apps,
+resources are exposed with REST-like paths using an MVC approach to separate
+concerns on the server.
+
+There is a notable exception made to this pattern, though, to support offline
+working.
+
+=== Offline support
+
+include::offline-support.adoc[leveloffset=+2,lines=24..-1]
+
+== Deployment
+
+include::deployment.adoc[leveloffset=+1,lines=24..-1]
+
+== Components
+
+* Authentication
+* Campaign management - creation, update, etc
+* Campaign operations and vaccination recording
+* Offline support - Browser-based component
+* FHIR server synchronisation

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -29,15 +29,17 @@ endif::[]
 
 == Introduction and Goals
 
-This is the pilot of a service to record children's vaccinations in schools and
-during catch-up clinics. This service provides consent and point-of-care
-services for SAIS teams and parents, and is designed to integrate with the
-Personal Demographics Service (PDS) and the national vaccination record.
+This is the prototype a service to manage vaccinations for school-aged children
+in schools and during catch-up clinics. This service will provide e-consent,
+campaign management and point-of-care services for SAIS teams and parents. The
+goal is for this service to integrate with the national vaccination record to
+record vaccinations. However, integration with the national vaccination record
+will not be part of this phase.
 
-This service is in Alpha and this pilot is being used in to explore designs and further
-our understandings of user requirements through user research. Requirements have
-been tailored to focus on user-facing features over non-functional requirements
-which have been, where possible, de-emphasised.
+This service is in Alpha and this pilot is being used in to explore designs and
+further our understandings of user requirements through user research.
+Requirements have been tailored to focus on user-facing features over
+non-functional requirements which have been, where possible, de-emphasised.
 
 === Requirements Overview
 
@@ -48,12 +50,12 @@ which have been, where possible, de-emphasised.
 ** Create consent invites.
 ** Record vaccinations administered.
 * Allow parents to respond to consent requests.
-* Operate in settings where there is no Internet access, i.e. offline working.
 
 .Non-Functional Requirements
 
 * Security
-** Simple authentication and authorisation model; the alpha team will issue individual logins, tied to email addresses, to each SAIS user.
+** Simple authentication and authorisation model; the alpha team will issue
+   individual logins, tied to email addresses, to each SAIS user.
 ** Security model appropriate for scale of experiment
 *** Each SAIS team will only be able to view and record vaccinations/patients
     for the school sessions that they manage
@@ -66,11 +68,7 @@ which have been, where possible, de-emphasised.
 ** Web application framework that enables accelerated delivery
 * Data persistence
 ** Data persisted between sessions and users
-** No long term data storage, i.e. beyond end of experiment
-** Support for offline functionality
-* Integration with NHS services (where possible)
-** Send events to National Vaccination Record
-** Use Personal Demographic Service (PDS) to perform NHS number lookup
+** No long term data storage, i.e. beyond end of testing phase(s)
 
 We won't need:
 
@@ -78,7 +76,11 @@ We won't need:
 * Authentication that's integrated with wider NHS or other SSO provider
 * Reporting capability
 * Long term maintainability of codebase
+* Offline functionality
 * Long term storage of data
+* Integration with NHS services
+** Send events to National Vaccination Record
+** Use Personal Demographic Service (PDS) to perform NHS number lookup
 
 <<<<
 == Architecture Constraints
@@ -91,10 +93,10 @@ We won't need:
   and not constrained to run on any one cloud platform.
 * The system must be deployed to NHS approved platforms.
 
-Additionally, there are some integrations which would be required in the
-production service, but which we consider optional while in Alpha. Where
-possible we will try to integrate with these services, but not treat it as a
-blocker if we cannot:
+Additionally, there are some integrations which will be required in the
+production service, but which we will be descoped for the current phase. They
+are listed here to help define the wider goal of this service. These services
+are:
 
 * National vaccination record service, to update the vaccination record for
   the patient. We do not yet know what this system looks like so it is unlikely
@@ -134,25 +136,6 @@ consent for their children to be vaccinated.
 Manage vaccinations for school-aged children Service::
 The service will be used by the SAIS team to record vaccinations.
 
-Vaccination Record::
-
-Service which will hold a record of vaccinations for citizens across the NHS.
-This service is currently being designed and it's final form is yet to be
-determined, however any new service created will very likely use a Rest
-FHIR API.
-+
-However, it is possible that in the interim this service will be DPS, which is
-built using Data Bricks and which uses file transfers for data input and output,
-so may present additional challenges.
-+
-This integration may not be available during during this alpha.
-
-PDS (Personal Demographics Service)::
-Service which will allow us to look up NHS numbers for patients who don't know
-theirs. Crucial for properly identifying patients.
-+
-This integration may not be available during during this alpha.
-
 == Solution strategy
 
 Certain solution strategy decisions are recorded as architecture decisions in
@@ -178,6 +161,11 @@ include::diagrams/container-view.puml[]
 ----
 endif::[]
 
+GOVUK Notify::
+This service used to send consent confirmations and other notifications to
+parents. It is an external service run by Government Digital Service (GDS) and
+in use by other NHS services.
+
 === Level 2: Component View
 
 ifdef::env-github[]
@@ -191,11 +179,6 @@ include::diagrams/component-view.puml[]
 ----
 endif::[]
 
-Browser Cache Storage::
-Data necessary for offline functionality is stored in the browser's cache
-storage. This is managed by the service worker, see the offline documentation
-for more information.
-
 Database::
 Relational storage used to store application data including campaign data,
 consent responses and vaccination events. In the case of the vaccination events,
@@ -203,6 +186,13 @@ this data would be uploaded to the national vaccination record and this data
 store would be used as temporary storage. However during the alpha phase
 uploading to the national vaccination record may not available, so the
 vaccination event data may be kept in this store until the end of the pilot.
+
+Sending email and SMS::
+For the current scale of this pilot the sending of emails will be done directly
+from the web servers. It is common for services to use separate workers to
+process API integration with external services to isolate the web application
+from possible network issues, but won't be necessary with the number of users
+using the pilot.
 
 == Runtime View
 
@@ -212,13 +202,6 @@ and delivered along with CSS and JavaScript to the client. Users login to the
 service using a standard login page, and as is standard with Ruby on Rails apps,
 resources are exposed with REST-like paths using an MVC approach to separate
 concerns on the server.
-
-There is a notable exception made to this pattern, though, to support offline
-working.
-
-=== Offline support
-
-include::offline-support.adoc[leveloffset=+2,lines=24..-1]
 
 == Deployment
 

--- a/docs/diagrams/component-view-future.puml
+++ b/docs/diagrams/component-view-future.puml
@@ -28,6 +28,7 @@ Boundary(aws, "AWS") {
   SystemDb_Ext(pds, "PDS", "")
 }
 
+System_Ext(govukNotify, "GOVUK Notify", "Email and SMS Service")
 SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server", $tags="outside_context")
 SystemDb_Ext(pds, "PDS", "", $tags="outside_context")
 
@@ -40,6 +41,7 @@ Rel(pages, serviceWorker, "Request Assets", "internal fetch")
 Rel(serviceWorker, cacheStorage, "Cache Assets")
 Rel(serviceWorker, webapp, "Request pages", "HTTPS")
 Rel(webapp, database, "Read and write data", "Postgres, TLS")
+Rel(webapp, govukNotify, "Send email and SMS")
 Rel(webapp, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
 Rel(webapp, pds, "NHS Number Lookup", $tags="optional")
 

--- a/docs/diagrams/component-view-future.puml
+++ b/docs/diagrams/component-view-future.puml
@@ -1,0 +1,49 @@
+@startuml
+
+!include <C4/C4_Component.puml>
+
+LAYOUT_TOP_DOWN()
+
+title "Manage Vaccinations For School-aged Children Component View"
+
+AddElementTag("outside_context", $bgColor="#CCC", $fontColor="#FFF")
+
+Person_Ext(sais, "SAIS Team", $tags="outside_context")
+Person_Ext(parents, "Parents", $tags="outside_context")
+
+Boundary(aws, "AWS") {
+  System_Boundary(manage, "Manage Vaccinations for School-aged Children", "") {
+    Container_Boundary(browser, "Browser Application", "JavaScript") {
+      Component(pages, "Web Pages", "HTML, CSS")
+      Component(serviceWorker, "Service Worker", "JavaScript")
+      ComponentDb_Ext(cacheStorage, "Browser Cache Storage", "On Disk")
+    }
+    Container_Boundary(server, "Server Application", "Ruby on Rails") {
+      Component(webapp, "Web Application", "Ruby on Rails")
+      ComponentDb(database, "Database", "PostgreSQL")
+    }
+  }
+
+  SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
+  SystemDb_Ext(pds, "PDS", "")
+}
+
+SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server", $tags="outside_context")
+SystemDb_Ext(pds, "PDS", "", $tags="outside_context")
+
+AddRelTag("optional", $textColor="black", $lineColor="black", $lineStyle="dashed")
+
+Rel(sais, pages, "Manage campaigns")
+Rel(sais, pages, "Record Child Vaccination")
+Rel(parents, pages, "Consent response")
+Rel(pages, serviceWorker, "Request Assets", "internal fetch")
+Rel(serviceWorker, cacheStorage, "Cache Assets")
+Rel(serviceWorker, webapp, "Request pages", "HTTPS")
+Rel(webapp, database, "Read and write data", "Postgres, TLS")
+Rel(webapp, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
+Rel(webapp, pds, "NHS Number Lookup", $tags="optional")
+
+
+SHOW_FLOATING_LEGEND()
+
+@enduml

--- a/docs/diagrams/component-view.puml
+++ b/docs/diagrams/component-view.puml
@@ -4,7 +4,7 @@
 
 LAYOUT_TOP_DOWN()
 
-title "Record Children's Vaccination's Component View"
+title "Manage Vaccinations For School-aged Children Component View"
 
 AddElementTag("outside_context", $bgColor="#CCC", $fontColor="#FFF")
 
@@ -12,12 +12,12 @@ Person_Ext(sais, "SAIS Team", $tags="outside_context")
 Person_Ext(parents, "Parents", $tags="outside_context")
 
 Boundary(aws, "AWS") {
-  System_Boundary(record, "Record Children's Vaccination", "") {
     Container_Boundary(browser, "Browser Application", "JavaScript") {
       Component(pages, "Web Pages", "HTML, CSS")
       Component(serviceWorker, "Service Worker", "JavaScript")
       ComponentDb_Ext(cacheStorage, "Browser Cache Storage", "On Disk")
     }
+  System_Boundary(manage, "Manage vaccinations for school-aged children", "") {
     Container_Boundary(server, "Server Application", "Ruby on Rails") {
       Component(webapp, "Web Application", "Ruby on Rails")
       ComponentDb(database, "Database", "PostgreSQL")

--- a/docs/diagrams/component-view.puml
+++ b/docs/diagrams/component-view.puml
@@ -12,36 +12,23 @@ Person_Ext(sais, "SAIS Team", $tags="outside_context")
 Person_Ext(parents, "Parents", $tags="outside_context")
 
 Boundary(aws, "AWS") {
-    Container_Boundary(browser, "Browser Application", "JavaScript") {
-      Component(pages, "Web Pages", "HTML, CSS")
-      Component(serviceWorker, "Service Worker", "JavaScript")
-      ComponentDb_Ext(cacheStorage, "Browser Cache Storage", "On Disk")
-    }
   System_Boundary(manage, "Manage vaccinations for school-aged children", "") {
     Container_Boundary(server, "Server Application", "Ruby on Rails") {
       Component(webapp, "Web Application", "Ruby on Rails")
       ComponentDb(database, "Database", "PostgreSQL")
     }
   }
-
-  SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
-  SystemDb_Ext(pds, "PDS", "")
 }
+System_Ext(govukNotify, "GOVUK Notify", "Email and SMS Service")
 
-SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server", $tags="outside_context")
-SystemDb_Ext(pds, "PDS", "", $tags="outside_context")
 
 AddRelTag("optional", $textColor="black", $lineColor="black", $lineStyle="dashed")
 
-Rel(sais, pages, "Manage campaigns")
-Rel(sais, pages, "Record Child Vaccination")
-Rel(parents, pages, "Consent response")
-Rel(pages, serviceWorker, "Request Assets", "internal fetch")
-Rel(serviceWorker, cacheStorage, "Cache Assets")
-Rel(serviceWorker, webapp, "Request pages", "HTTPS")
+Rel(sais, webapp, "Manage campaigns")
+Rel(sais, webapp, "Record Child Vaccination")
+Rel(parents, webapp, "Consent response")
 Rel(webapp, database, "Read and write data", "Postgres, TLS")
-Rel(webapp, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
-Rel(webapp, pds, "NHS Number Lookup", $tags="optional")
+Rel(webapp, govukNotify, "Send email and SMS")
 
 
 SHOW_FLOATING_LEGEND()

--- a/docs/diagrams/container-view-future.puml
+++ b/docs/diagrams/container-view-future.puml
@@ -1,0 +1,39 @@
+@startuml
+
+!include <C4/C4_Container.puml>
+
+LAYOUT_TOP_DOWN()
+
+title "Manage Vaccinations For School-aged Children Container View"
+
+AddElementTag("outside_context", $bgColor="#CCC", $fontColor="#FFF")
+
+Person_Ext(sais, "SAIS Team", $tags="outside_context")
+Person_Ext(parents, "Parents", $tags="outside_context")
+
+Boundary(aws, "AWS") {
+  System_Boundary(manage, "Manage Vaccinations for School-aged Children Vaccination", "") {
+    Container(browser, "Browser Application", "JavaScript")
+    Container(server, "Server Application", "Ruby on Rails")
+  }
+
+  SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
+  SystemDb_Ext(pds, "PDS", "")
+}
+
+SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server", $tags="outside_context")
+SystemDb(pds, "PDS", "", $tags="outside_context")
+
+AddRelTag("optional", $textColor="black", $lineColor="black", $lineStyle="dashed")
+
+Rel(server, browser, "Code and assets", "HTTPS")
+Rel(browser, server, "Requests pages", "HTTPS")
+Rel(sais, browser, "Manage campaigns")
+Rel(sais, browser, "Record Child Vaccination")
+Rel(parents, browser, "Consent response")
+Rel(server, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
+Rel(server, pds, "NHS Number Lookup", $tags="optional")
+
+SHOW_FLOATING_LEGEND()
+
+@enduml

--- a/docs/diagrams/container-view-future.puml
+++ b/docs/diagrams/container-view-future.puml
@@ -21,6 +21,7 @@ Boundary(aws, "AWS") {
   SystemDb_Ext(pds, "PDS", "")
 }
 
+System_Ext(govukNotify, "GOVUK Notify", "Email and SMS Service")
 SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server", $tags="outside_context")
 SystemDb(pds, "PDS", "", $tags="outside_context")
 
@@ -31,6 +32,7 @@ Rel(browser, server, "Requests pages", "HTTPS")
 Rel(sais, browser, "Manage campaigns")
 Rel(sais, browser, "Record Child Vaccination")
 Rel(parents, browser, "Consent response")
+Rel(server, govukNotify, "Send email and SMS")
 Rel(server, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
 Rel(server, pds, "NHS Number Lookup", $tags="optional")
 

--- a/docs/diagrams/container-view.puml
+++ b/docs/diagrams/container-view.puml
@@ -12,27 +12,19 @@ Person_Ext(sais, "SAIS Team", $tags="outside_context")
 Person_Ext(parents, "Parents", $tags="outside_context")
 
 Boundary(aws, "AWS") {
-    Container(browser, "Browser Application", "JavaScript")
   System_Boundary(manage, "Service", "") {
     Container(server, "Server Application", "Ruby on Rails")
   }
-
-  SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
-  SystemDb_Ext(pds, "PDS", "")
 }
 
-SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server", $tags="outside_context")
-SystemDb(pds, "PDS", "", $tags="outside_context")
+System_Ext(govukNotify, "GOVUK Notify", "Email and SMS Service")
 
 AddRelTag("optional", $textColor="black", $lineColor="black", $lineStyle="dashed")
 
-Rel(server, browser, "Code and assets", "HTTPS")
-Rel(browser, server, "Requests pages", "HTTPS")
-Rel(sais, browser, "Manage campaigns")
-Rel(sais, browser, "Record Child Vaccination")
-Rel(parents, browser, "Consent response")
-Rel(server, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
-Rel(server, pds, "NHS Number Lookup", $tags="optional")
+Rel(sais, server, "Manage campaigns")
+Rel(sais, server, "Record Child Vaccination")
+Rel(parents, server, "Consent response")
+Rel(server, govukNotify, "Send email and SMS")
 
 SHOW_FLOATING_LEGEND()
 

--- a/docs/diagrams/container-view.puml
+++ b/docs/diagrams/container-view.puml
@@ -4,7 +4,7 @@
 
 LAYOUT_TOP_DOWN()
 
-title "Record Children's Vaccination's Container View"
+title "Manage Vaccinations For School-aged Children Container View"
 
 AddElementTag("outside_context", $bgColor="#CCC", $fontColor="#FFF")
 
@@ -12,8 +12,8 @@ Person_Ext(sais, "SAIS Team", $tags="outside_context")
 Person_Ext(parents, "Parents", $tags="outside_context")
 
 Boundary(aws, "AWS") {
-  System_Boundary(record, "Record Children's Vaccination", "") {
     Container(browser, "Browser Application", "JavaScript")
+  System_Boundary(manage, "Service", "") {
     Container(server, "Server Application", "Ruby on Rails")
   }
 

--- a/docs/diagrams/context-view-future.puml
+++ b/docs/diagrams/context-view-future.puml
@@ -1,0 +1,27 @@
+@startuml
+
+!include <C4/C4_Context.puml>
+
+LAYOUT_TOP_DOWN()
+
+title "Manage Vaccinations For School-aged Children Context Diagram"
+
+Person_Ext(sais, "SAIS Team")
+Person_Ext(parents, "Parents")
+
+System(manage, "Manage vaccinations for school-aged children", "Ruby on Rails, HTML, Javascript")
+
+SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
+SystemDb_Ext(pds, "PDS", "")
+
+AddRelTag("optional", $textColor="black", $lineColor="black", $lineStyle="dashed")
+
+Rel(sais, manage, "Manage campaigns")
+Rel(sais, manage, "Record Child Vaccination")
+Rel(parents, manage, "Consent response")
+Rel(manage, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
+Rel(manage, pds, "NHS Number Lookup", $tags="optional")
+
+SHOW_FLOATING_LEGEND()
+
+@enduml

--- a/docs/diagrams/context-view.puml
+++ b/docs/diagrams/context-view.puml
@@ -4,12 +4,12 @@
 
 LAYOUT_TOP_DOWN()
 
-title "Record Children's Vaccination's Context Diagram"
+title "Manage Vaccinations For School-aged Children Context Diagram"
 
 Person_Ext(sais, "SAIS Team")
 Person_Ext(parents, "Parents")
 
-System(record, "Record Children's Vaccination", "Ruby on Rails, HTML, Javascript")
+System(manage, "Manage vaccinations for school-aged children", "Ruby on Rails, HTML, Javascript")
 
 SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
 SystemDb_Ext(pds, "PDS", "")

--- a/docs/diagrams/context-view.puml
+++ b/docs/diagrams/context-view.puml
@@ -11,16 +11,11 @@ Person_Ext(parents, "Parents")
 
 System(manage, "Manage vaccinations for school-aged children", "Ruby on Rails, HTML, Javascript")
 
-SystemDb_Ext(vaccineRecord, "Vaccination Record", "FHIR Server")
-SystemDb_Ext(pds, "PDS", "")
-
 AddRelTag("optional", $textColor="black", $lineColor="black", $lineStyle="dashed")
 
-Rel(sais, record, "Manage campaigns")
-Rel(sais, record, "Record Child Vaccination")
-Rel(parents, record, "Consent response")
-Rel(record, vaccineRecord, "Updates Child Vaccination History", $tags="optional")
-Rel(record, pds, "NHS Number Lookup", $tags="optional")
+Rel(sais, manage, "Manage campaigns")
+Rel(sais, manage, "Record Child Vaccination")
+Rel(parents, manage, "Consent response")
 
 SHOW_FLOATING_LEGEND()
 

--- a/docs/diagrams/development-process-overview.puml
+++ b/docs/diagrams/development-process-overview.puml
@@ -2,7 +2,7 @@
 
 !include <C4/C4_Dynamic.puml>
 
-title "Record Children's Vaccination's Development process overview"
+title "Manage Vaccinations For School-aged Children Development process overview"
 
 Person(devA, "Alice", "Developer")
 Person(devB, "Bob", "Developer")

--- a/docs/diagrams/failed-malicious-get-of-csrf.puml
+++ b/docs/diagrams/failed-malicious-get-of-csrf.puml
@@ -4,17 +4,17 @@ title Failed malicious GET of CSRF
 
 autoactivate on
 
-== User is still authenticated with record.nhs.uk ==
+== User is still authenticated with manage.nhs.uk ==
 
 group Malicious update to patient data
     Browser -> evil.site: GET /
     return 200 OK
     note right
         // Malicious script attempts to retrieve a csrf token
-        fetch("https://record.nhs.uk/csrf")
+        fetch("https://manage.nhs.uk/csrf")
     end note
 
-    Browser -[#red]>x record.nhs.uk: GET /csrf
+    Browser -[#red]>x manage.nhs.uk: GET /csrf
     note right #FCC
         Cross-Origin Request Blocked by browser
     end note

--- a/docs/diagrams/failed-malicious-offline-post-without-csrf.puml
+++ b/docs/diagrams/failed-malicious-offline-post-without-csrf.puml
@@ -4,27 +4,27 @@ title Failed malicious offline POST without CSRF
 
 autoactivate on
 
-== User is still authenticated with record.nhs.uk ==
+== User is still authenticated with manage.nhs.uk ==
 
 group Malicious update to patient data
     Browser -> evil.site: GET /
     return 200 OK
     note right
-        // Malicious form that POSTs to record.nhs.uk
-        <form action="https://record.nhs.uk/patients/1/vaccinations" ...>
+        // Malicious form that POSTs to manage.nhs.uk
+        <form action="https://manage.nhs.uk/patients/1/vaccinations" ...>
           <input type="hidden" name="vaccination" value="mmr" />
           <input type="hidden" name="vaccination_given" value="false" />
         ...
     end note
 
-    Browser -> record.nhs.uk: POST /patients/1/vaccinations/
+    Browser -> manage.nhs.uk: POST /patients/1/vaccinations/
     note right
         vaccination=mmr
         vaccination_performed=false
     end note
 
-    Browser <-[#red]-x record.nhs.uk: 422 Unprocessable entity
-    deactivate record.nhs.uk
+    Browser <-[#red]-x manage.nhs.uk: 422 Unprocessable entity
+    deactivate manage.nhs.uk
     note right #FCC
         Missing CSRF token
     end note

--- a/docs/diagrams/failed-malicious-post-with-csrf.puml
+++ b/docs/diagrams/failed-malicious-post-with-csrf.puml
@@ -4,25 +4,25 @@ title Failed malicious POST with CSRF
 
 autoactivate on
 
-== User is still authenticated with record.nhs.uk ==
+== User is still authenticated with manage.nhs.uk ==
 
 Browser -> evil.site: GET /
 return 200 OK
 note right
-    // Malicious form that POSTs to record.nhs.uk
-    <form action="https://record.nhs.uk/patients/1/vaccinations" ...>
+    // Malicious form that POSTs to manage.nhs.uk
+    <form action="https://manage.nhs.uk/patients/1/vaccinations" ...>
       <input type="hidden" name="vaccination" value="mmr" />
       <input type="hidden" name="vaccination_given" value="false" />
     ...
 end note
 
-Browser -> record.nhs.uk: POST /patients/1/vaccinations
+Browser -> manage.nhs.uk: POST /patients/1/vaccinations
 note right
     vaccine=mmr
     vaccination_given=false
 end note
-Browser <-[#red]-x record.nhs.uk: 422 Unprocessable entity
-deactivate record.nhs.uk
+Browser <-[#red]-x manage.nhs.uk: 422 Unprocessable entity
+deactivate manage.nhs.uk
 note right #FCC
     Missing CSRF token
 end note

--- a/docs/diagrams/failed-offline-post-with-outdated-csrf.puml
+++ b/docs/diagrams/failed-offline-post-with-outdated-csrf.puml
@@ -5,7 +5,7 @@ title Failed offline POST with outdated CSRF
 autoactivate on
 
 group Prepare to work offline
-    Browser -> record.nhs.uk: GET /patients/1/vaccinations/new
+    Browser -> manage.nhs.uk: GET /patients/1/vaccinations/new
     return 200 OK
     note right
         // Form including CSRF token
@@ -22,15 +22,15 @@ end
 == Browser comes back online ==
 
 group Update patient data
-    Browser -> record.nhs.uk: POST /patients/1/vaccinations/
+    Browser -> manage.nhs.uk: POST /patients/1/vaccinations/
     note right
         vaccination=mmr
         vaccination_given=false
         // This token is now old
         csrf_token="CSRF token"
     end note
-    Browser <-[#red]-x record.nhs.uk: 422 Unprocessable entity
-    deactivate record.nhs.uk
+    Browser <-[#red]-x manage.nhs.uk: 422 Unprocessable entity
+    deactivate manage.nhs.uk
     note right #FCC
         Invalid CSRF token
     end note

--- a/docs/diagrams/malicious-offline-post-without-csrf.puml
+++ b/docs/diagrams/malicious-offline-post-without-csrf.puml
@@ -4,20 +4,20 @@ title Malicious offline POST without CSRF
 
 autoactivate on
 
-== User is still authenticated with record.nhs.uk ==
+== User is still authenticated with manage.nhs.uk ==
 
 group Malicious update to patient data
     Browser -> evil.site: GET /
     return 200 OK
     note right
-        // Malicious form that POSTs to record.nhs.uk
-        <form action="https://record.nhs.uk/patients/1/vaccinations" ...>
+        // Malicious form that POSTs to manage.nhs.uk
+        <form action="https://manage.nhs.uk/patients/1/vaccinations" ...>
           <input type="hidden" name="vaccination" value="mmr" />
           <input type="hidden" name="vaccination_given" value="false" />
         ...
     end note
 
-    Browser -> record.nhs.uk: POST /patients/1/vaccinations
+    Browser -> manage.nhs.uk: POST /patients/1/vaccinations
     note right
         vaccine=mmr
         vaccination_performed=false

--- a/docs/diagrams/service-worker.puml
+++ b/docs/diagrams/service-worker.puml
@@ -6,7 +6,7 @@ title Manage vaccinations for school-aged children Service Worker
 
 LAYOUT_TOP_DOWN()
 
-System_Boundary(record, "Manage vaccinations for school-aged children") {
+System_Boundary(manage, "Manage vaccinations for school-aged children") {
   Container_Boundary(browser, "Web Browser") {
     Component(frontend, "Front-End", "HTML, Javascript")
     Component(serviceWorker, "Service Worker", "Javascript")

--- a/docs/diagrams/staging-deployment-process.puml
+++ b/docs/diagrams/staging-deployment-process.puml
@@ -5,7 +5,7 @@
 title "Manage vaccinations for school-aged children Staging Deployment Process"
 
 System_Ext(herokuAPI, "Heroku Platform API")
-Boundary(record, "Record Children's Vaccination", "Staging") {
+Boundary(manage, "Manage Vaccinations for School-aged Children", "Staging") {
   Container(serverStaging, "Web Application", "Ruby on Rails")
   ContainerDb(dbStaging, "Database", "PostgreSQL")
 }

--- a/docs/diagrams/successful-offline-post-with-csrf.puml
+++ b/docs/diagrams/successful-offline-post-with-csrf.puml
@@ -4,7 +4,7 @@ title Successful offline POST with CSRF
 autoactivate on
 
 group Prepare to work offline
-    Browser -> record.nhs.uk: GET /patients/1/vaccinations/new
+    Browser -> manage.nhs.uk: GET /patients/1/vaccinations/new
     return 200 OK
     note right
         // HTML form without CSRF token
@@ -19,12 +19,12 @@ end
 
 == Browser comes back online ==
 
-Browser -> record.nhs.uk: GET /csrf
+Browser -> manage.nhs.uk: GET /csrf
 return 200 OK
 note right: "New CSRF token"
 
 group Update patient data
-    Browser -> record.nhs.uk: POST /patients/1/vaccinations/
+    Browser -> manage.nhs.uk: POST /patients/1/vaccinations/
     note right
         vaccination=mmr
         vaccination_performed=false

--- a/docs/diagrams/successful-offline-post-without-csrf.puml
+++ b/docs/diagrams/successful-offline-post-without-csrf.puml
@@ -5,7 +5,7 @@ title Successful offline POST without CSRF
 autoactivate on
 
 group Prepare to work offline
-    Browser -> record.nhs.uk: GET /patients/1/vaccinations/new
+    Browser -> manage.nhs.uk: GET /patients/1/vaccinations/new
     return 200 OK
     note right
         // HTML form without CSRF token
@@ -21,7 +21,7 @@ end
 == Browser comes back online ==
 
 group Update patient data
-    Browser -> record.nhs.uk: POST /patients/1/vaccinations/
+    Browser -> manage.nhs.uk: POST /patients/1/vaccinations/
     note right
         vaccination=mmr
         vaccination_performed=false

--- a/docs/diagrams/successful-post-with-csrf.puml
+++ b/docs/diagrams/successful-post-with-csrf.puml
@@ -4,14 +4,14 @@ title Successful POST with CSRF
 
 autoactivate on
 
-Browser -> record.nhs.uk: GET /patients/1/vaccinations/new
+Browser -> manage.nhs.uk: GET /patients/1/vaccinations/new
 return 200 OK
 
 note right
     csrf="Unique CSRF Token"
 end note
 
-Browser -> record.nhs.uk: POST /patients/1/vaccinations
+Browser -> manage.nhs.uk: POST /patients/1/vaccinations
 note right
     vaccine=mmr
     vaccination_given=true

--- a/docs/diagrams/testing-deployment-process.puml
+++ b/docs/diagrams/testing-deployment-process.puml
@@ -5,7 +5,7 @@
 title "Manage vaccinations for school-aged children Testing Deployment Process"
 
 System_Ext(herokuAPI, "Heroku Platform API")
-Boundary(record, "Record Children's Vaccination", "Staging") {
+Boundary(manage, "Manage Vaccinations for School-aged Children Vaccination", "Staging") {
   Container(serverStaging, "Web Application", "Ruby on Rails")
   ContainerDb(dbStaging, "Database", "PostgreSQL")
 }


### PR DESCRIPTION
This updates the architecture docs, major changes being:
- Copy current architecture docs to a "future" version, reflecting that our current scope is smaller.
- Remove National vaccination record and PDS from current architecture version.
- Add GOVUK Notify to current and future state.